### PR TITLE
Improve filtering, rank display, and play history on song page

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,6 @@
 <template>
   <v-app :style="{ background }">
+    <div id="modals"></div>
     <MainNav />
     <NuxtLayout :name="layout"></NuxtLayout>
     <SettingsModal />

--- a/components/wacca/WaccaChart.vue
+++ b/components/wacca/WaccaChart.vue
@@ -42,6 +42,7 @@ const props = defineProps({
   playerHistory: Array,
   song: Object,
   loading: Boolean,
+  difficultyFilter: Number,
 });
 
 const version = useState("version");
@@ -113,6 +114,10 @@ const playerHistoryFormatted = computed(() => {
     }
   }
 
+  if (props.difficultyFilter) {
+    return [datasets[props.difficultyFilter - 1]];
+  }
+
   return datasets;
 });
 
@@ -175,7 +180,20 @@ function updateChart() {
   chart.resetZoom();
 }
 
+function difficultyFilter(difficulty) {
+  if (!chart) return;
+
+  for (let i = props.playerHistory.length - 1; i >= 0; i--) {
+    // Hide all datasets except the one we filtered to
+    // Show all if filter is set to null, thus disabling
+    chart.setDatasetVisibility(i, !difficulty || i == difficulty - 1);
+  }
+
+  chart.update();
+}
+
 defineExpose({
   updateChart,
+  difficultyFilter,
 });
 </script>

--- a/components/wacca/WaccaChart.vue
+++ b/components/wacca/WaccaChart.vue
@@ -11,6 +11,9 @@
       <div>No plays yet. Go for it!</div>
     </div>
   </div>
+  <Teleport to="#modals">
+    <WaccaPlayModal v-if="modalOpen" :play="selectedPlay" @close-modal="closeModal"></WaccaPlayModal>
+  </Teleport>
 </template>
 
 <style scoped lang="scss">
@@ -54,6 +57,8 @@ const filteredsheets = computed(() => {
 });
 
 const playerChart = ref(null);
+const selectedPlay = ref(null);
+const modalOpen = ref(false);
 
 let chart;
 
@@ -104,11 +109,13 @@ const playerHistoryFormatted = computed(() => {
         datasets[score.info.music_difficulty - 1].data.unshift({
           x: new Date("2022-09-01T00:00:00+09:00"),
           y: score.info.score,
+          historyIndex: i,
         });
       } else {
         datasets[score.info.music_difficulty - 1].data.push({
           x: new Date(score.info.user_play_date),
           y: score.info.score,
+          historyIndex: i,
         });
       }
     }
@@ -169,6 +176,31 @@ onMounted(() => {
           },
         },
       },
+
+      onHover: (event, chartElement) => {
+        const canvas = event.native.target;
+        
+        if (chartElement.length) {
+          canvas.style.cursor = 'pointer'; // Change cursor to pointer on hover
+        } else {
+          canvas.style.cursor = 'default'; // Reset cursor when not hovering
+        }
+      },
+
+      onClick: function(event) {
+        const chart = event.chart;
+        const points = chart.getElementsAtEventForMode(event, 'nearest', { intersect: true }, true);
+        if (points.length > 0)
+        {
+          const point = points[0];
+          const datasetInfo = chart.data.datasets[point.datasetIndex];
+          const pointData = datasetInfo.data[point.index];
+          const play = props.playerHistory[pointData.historyIndex];
+
+          selectedPlay.value = play;
+          modalOpen.value = true;
+        }
+      },
     },
   });
 });
@@ -190,6 +222,11 @@ function difficultyFilter(difficulty) {
   }
 
   chart.update();
+}
+
+function closeModal() {
+  selectedPlay.value = null;
+  modalOpen.value = false;
 }
 
 defineExpose({

--- a/components/wacca/WaccaHistogram.vue
+++ b/components/wacca/WaccaHistogram.vue
@@ -108,6 +108,16 @@ onMounted(() => {
       },
 
       plugins: {
+        title: {
+          display: true,
+          text: props.label,
+          font: {
+            size: 16,
+          },
+        },
+        legend: {
+          display: false,
+        },
         tooltip: {
           callbacks: {
             title: (context) => {

--- a/components/wacca/WaccaPlay.vue
+++ b/components/wacca/WaccaPlay.vue
@@ -1,5 +1,5 @@
 <template>
-  <NuxtLink :to="`/wacca/songs/${song.id}`" style="text-decoration: none">
+  <component :is="force-expand ? 'v-fragment' : NuxtLink" :to="`/wacca/songs/${song.id}`" style="text-decoration: none">
     <div
       class="play"
       :class="{ expanded, 'is-record': play.info.is_new_record }"
@@ -54,7 +54,7 @@
       </div>
 
       <Collapse :when="expanded">
-        <div class="collapsible">
+        <div :class="{ collapsible: !props.forceExpand }">
           <div class="play-detail">
             <div class="play-judgements">
               <div
@@ -113,7 +113,7 @@
         </div>
       </Collapse>
 
-      <div class="play-expand">
+      <div class="play-expand" v-if="!props.forceExpand">
         <v-btn rounded @click.prevent="expand" color="primary">
           <div v-if="!expanded">
             <v-icon>mdi-chevron-down</v-icon>
@@ -126,7 +126,7 @@
         </v-btn>
       </div>
     </div>
-  </NuxtLink>
+  </component>
 </template>
 
 <style scoped lang="scss">
@@ -405,12 +405,14 @@ $cover-size: 100px;
 <script setup>
 import { Collapse } from "vue-collapsed";
 import { formatDifficulty } from "~/assets/js/util";
+import { NuxtLink } from "#components";
 const difficultyInternal = useState("difficultyInternal");
 
 import waccaSongs from "~~/assets/wacca/waccaSongs.js";
 
 const props = defineProps({
   play: Object,
+  forceExpand: Boolean,
 });
 
 const song = computed(() => {
@@ -427,7 +429,7 @@ function formatDate(date) {
   return new Date(date).toLocaleString();
 }
 
-const expanded = ref(false);
+const expanded = ref(props.forceExpand || false);
 function expand() {
   expanded.value = !expanded.value;
 }

--- a/components/wacca/WaccaPlayModal.vue
+++ b/components/wacca/WaccaPlayModal.vue
@@ -20,9 +20,11 @@
 </template>
 
 <style scoped lang="scss">
-.modal-content {
-  flex: 0 1 1000px;
-  transform: translateX(-10px);
+.modal.on {
+  .modal-content {
+    flex: 0 1 1000px;
+    transform: translateX(-8px);
+  }
 }
 </style>
 

--- a/components/wacca/WaccaPlayModal.vue
+++ b/components/wacca/WaccaPlayModal.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="modal on" @click="close">
+    <div class="modal-content" @click.stop>
+      <v-card>
+        <v-card-title>
+          <div class="d-flex justify-space-between align-center">
+            Play Details
+            <v-btn icon variant="plain" @click="close">
+              <v-icon>mdi-close</v-icon>
+            </v-btn>
+          </div>
+        </v-card-title>
+
+        <v-card-text>
+          <WaccaPlay :play="props.play" force-expand @click="close" />
+        </v-card-text>
+      </v-card>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.modal-content {
+  flex: 0 1 1000px;
+  transform: translateX(-10px);
+}
+</style>
+
+<script setup>
+  import { defineEmits } from 'vue';
+
+  const emit = defineEmits(['closeModal']);
+
+  const props = defineProps({
+    play: {
+      type: Object,
+      required: true,
+    },
+  });
+
+  const close = () => {
+    emit('closeModal');
+  };
+</script>

--- a/components/wacca/WaccaSongSheets.vue
+++ b/components/wacca/WaccaSongSheets.vue
@@ -4,13 +4,16 @@
       v-for="(difficulty, i) in filteredSheets"
       :key="i"
       class="song-difficulty"
+      @click="difficultyClick(i + 1)"
+      @mouseover="hover = i + 1"
+      @mouseleave="hover = null"
     >
       <WaccaMedal :medal="medal(i)" />
 
       <WaccaDifficultyPill
         :i="i + 1"
         :difficulty="difficulty.difficulty"
-        class="active"
+        :class="{ active: isActiveDifficulty(i + 1) }"
       />
 
       <div
@@ -29,7 +32,9 @@
 <style scoped lang="scss">
 .song-difficulty {
   margin-bottom: 5px;
+  cursor: pointer;
 }
+
 .song-difficulty-bottom {
   background-color: white;
   color: black;
@@ -64,9 +69,12 @@
 const props = defineProps({
   song: Object,
   playerData: Object,
+  selectedDifficulty: Number,
+  onDifficultyClick: Function,
 });
 
 const version = useState("version");
+const hover = ref(null);
 
 const grades = [
   "grade_d_count",
@@ -109,6 +117,18 @@ function medal(difficulty) {
   }
 
   return "none";
+}
+
+function isActiveDifficulty(index) {
+  return !props.selectedDifficulty || index === props.selectedDifficulty || hover.value == index
+}
+
+function difficultyClick(index) {
+  if (!props.onDifficultyClick) {
+    return false
+  }
+
+  return props.onDifficultyClick(index)
 }
 
 const filteredSheets = computed(() => {


### PR DESCRIPTION
The proposed changes in this MR would apply to individual song pages.

## Your Scores
- The difficulty pills can now be used as filters for the graph to only display a single difficulty.
- Hovering over and clicking on a point on the graph now opens a modal with the full details from that play.
  - This data was already being retrieved from the API, but wasn't displayed anywhere for users to see it. (Aside from recent plays, which only includes the player's 100 most recent.)

## Histograms
- Disabled legend - The legend allows hiding individual datasets, which doesn't really make sense for single dataset charts.
- Replaced with title instead, so it is still clear which difficulty the graph applies to.

## Leaderboards
- Add secondary sort of date to leaderboards. When players have identical scores, the player who achieved the score first will be displayed higher.
- "Your Rank" display under leaderboards section. This is meant to be a bit more convenient than scrolling through the list searching for your name. If your score is tied with other players, the lowest number is used as the display rank. (I.e. If  you get an AM it will always display your rank as 1; players with the same score "share" the same rank.)
  - It also displays out of how many scores, although this is limited by the backend only returning 100 records. If there are a full 100, it displays "100+" so that users know there are probably more than 100.
  - If you have not played the chart or are not in the top 100, it will display "Unranked".