### PR TITLE
Quality of Life

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MITHICAL_BACKEND_URL=https://my.backend.url

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ It's a Nuxt application.
 
 use `yarn dev` to start the development server.
 
-Make sure a mithical-backend (not provided) is running at nuxt.config.ts -> apiUrl.
+Make sure a mithical-backend (not provided) is running. Create a `.env` file at the root and set URLs to override the defaults. See `.env.example` file.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,7 +20,7 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     public: {
-      apiUrl: "http://localhost:3001",
+      apiUrl: process.env.MITHICAL_BACKEND_URL || "http://localhost:3001",
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "chart.js": "^4.4.4",
     "chartjs-adapter-moment": "^1.0.1",
     "chartjs-plugin-zoom": "^2.0.1",
-    "fuzzysort": "^3.0.2",
+    "fuzzysort": "^3.1.0",
     "moment": "^2.30.1",
     "nuxt": "^3.13.2",
     "sass-embedded": "^1.79.3",

--- a/pages/wacca/songs/index.vue
+++ b/pages/wacca/songs/index.vue
@@ -381,9 +381,9 @@ const sortOptions = [
       }
 
       if (sortOrder.value == "asc") {
-        return aTitle.localeCompare(bTitle);
+        return aTitle.localeCompare(bTitle, language.value);
       } else {
-        return bTitle.localeCompare(aTitle);
+        return bTitle.localeCompare(aTitle, language.value);
       }
     },
   },
@@ -391,9 +391,9 @@ const sortOptions = [
     text: "Artist",
     sortFunction: (a, b) => {
       if (sortOrder.value == "asc") {
-        return a.artist.localeCompare(b.artist);
+        return a.artist.localeCompare(b.artist, language.value);
       } else {
-        return b.artist.localeCompare(a.artist);
+        return b.artist.localeCompare(a.artist, language.value);
       }
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2704,10 +2704,10 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-fuzzysort@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/fuzzysort/-/fuzzysort-3.0.2.tgz#22c84fb8776ad3646d9ac9bae500ee12370c770e"
-  integrity sha512-ZyahVgxvckB1Qosn7YGWLDJJp2XlyaQ2WmZeI+d0AzW0AMqVYnz5N89G6KAKa6m/LOtv+kzJn4lhDF/yVg11Cg==
+fuzzysort@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fuzzysort/-/fuzzysort-3.1.0.tgz#4d7832d8fa48ad381753eaa7a7aae9927bdc10a8"
+  integrity sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==
 
 gauge@^3.0.0:
   version "3.0.2"
@@ -4708,16 +4708,7 @@ streamx@^2.15.0:
   optionalDependencies:
     bare-events "^2.2.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4749,14 +4740,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5355,16 +5339,7 @@ wide-align@^1.1.2:
   dependencies:
     string-width "^1.0.2 || 2 || 3 || 4"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
- Fuzzysort [3.1.0 handles diacritics / accents / ligatures](https://github.com/farzher/fuzzysort?tab=readme-ov-file#v310), which makes searching for titles like `ÅMARA` and `Ouvertüre` easier. :)
- Sort should use the locale sorting method for the selected language, instead of falling back to the user's locale. (In practice I don't know how much this matters, and most users will have these matching anyway.)
- Using env makes it easier for collaborators to set their backend url without changing a git tracked file.