### PR TITLE
Fix `gameVersion` for all charts in the consts file

### DIFF
--- a/assets/wacca/waccaSongs.js
+++ b/assets/wacca/waccaSongs.js
@@ -6,7 +6,7 @@ const waccaSongs = [
     artist: "DJ Genki feat. Yukacco",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 180,
     imageName:
       "e7f2de4d9fc3ba66dd1ce15966708d4acd1d155e3b16ffb083296be9b893e5b0.png",
@@ -15,17 +15,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -37,7 +37,7 @@ const waccaSongs = [
     artist: "USAO",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 200,
     imageName:
       "f2774f75c0a2830f2804e7bda0fdc3b8bf6972d00892b42c90ffcb4c1c587a78.png",
@@ -46,17 +46,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -68,7 +68,7 @@ const waccaSongs = [
     artist: "Massive New Krew",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 155,
     imageName:
       "544a0487889573ce85bf8ebad8a143d098e9107fe691d95416de1404c1dbdebb.png",
@@ -77,17 +77,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -99,7 +99,7 @@ const waccaSongs = [
     artist: "P*Light",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 180,
     imageName:
       "9276b2ec3e628e1540322f04edc6ec93421e640c3397dc721c53218f9a5a9c3f.png",
@@ -108,22 +108,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "TII★GER",
       },
     ],
@@ -135,7 +135,7 @@ const waccaSongs = [
     artist: "黒うさP feat. 初音ミク",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 154,
     imageName:
       "38cf54ac6dae6f949715cd52deea722ac44aa0cf69e37e40c9fc3144fb68cb37.png",
@@ -144,17 +144,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -166,7 +166,7 @@ const waccaSongs = [
     artist: "UNISON SQUARE GARDEN",
     dateAdded: 0,
     dateRemoved: 20211018,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 132,
     imageName:
       "3b66721c86cf49334cdbc482fc14a7462b9175916132d5129f22e584e04e0b46.png",
@@ -175,17 +175,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -197,7 +197,7 @@ const waccaSongs = [
     artist: "米津玄師",
     dateAdded: 0,
     dateRemoved: 20220124,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 200,
     imageName:
       "66eaa0c22b1e4068f058cbe52ab55fc80b7103a192f9bb208b8ac853fe4244d6.png",
@@ -206,17 +206,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 6.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -228,7 +228,7 @@ const waccaSongs = [
     artist: "あんさんぶるスターズ！ オン・ステージ",
     dateAdded: 0,
     dateRemoved: 20211018,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 142,
     imageName:
       "a3c77ed0c115bd0f5eb9bbbfb1968e86c82837a097515cd55a207aa39e039ae3.png",
@@ -237,17 +237,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 5.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -259,7 +259,7 @@ const waccaSongs = [
     artist: "REDALiCE feat. Ayumi Nomiya",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 175,
     imageName:
       "953422f24184eb7b15a3e7836f867e16c9d534e6fb10151a6d1e6e1c8fc1ca39.png",
@@ -268,17 +268,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -290,7 +290,7 @@ const waccaSongs = [
     artist: "t+pazolite",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 191,
     imageName:
       "4b7b39f5d86087e22dd5e6c87b190a9ff068d7bcf30d84312730f5af9313c559.png",
@@ -299,17 +299,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -321,7 +321,7 @@ const waccaSongs = [
     artist: "いとうかなこ",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 179,
     imageName:
       "e392e8e627fbc48161d8a3b6840d3d5719ed8cc395d8e16c0675850a8636dcc4.png",
@@ -330,17 +330,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 6.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -352,7 +352,7 @@ const waccaSongs = [
     artist: "DJ Noriken",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 170,
     imageName:
       "4a7627e09891b97d1a273326546f3bada20129ac08760ade1a4c070175530474.png",
@@ -361,17 +361,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -383,7 +383,7 @@ const waccaSongs = [
     artist: "DJ Myosuke",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 200,
     imageName:
       "87f8ae1e778028e884cee72c603844af958f9cb0ba1e8f25d33ee5b67ed72336.png",
@@ -392,17 +392,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -414,7 +414,7 @@ const waccaSongs = [
     artist: "歌組雪月花(夜々(原田ひとみ)・いろり(茅野愛衣)・小紫(小倉唯))",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 160,
     imageName:
       "9fde4819488483e8a5abb84d4bb1a607cacc036c35fdc765471fc939199dfb61.png",
@@ -423,22 +423,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -450,7 +450,7 @@ const waccaSongs = [
     artist: "ナユタン星人 feat. 初音ミク",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 152,
     imageName:
       "9007ffc8de24e2aa43b2f677c0f3f05ab71e257c66cb445bef63ae32f4e7832f.png",
@@ -459,17 +459,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 6.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -481,7 +481,7 @@ const waccaSongs = [
     artist: "ハチ",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 95,
     imageName:
       "58129a3f45ff089e9b3eee033e9ba14b9df526b91b7d9436df04b64c44fe4dc5.png",
@@ -490,17 +490,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -512,7 +512,7 @@ const waccaSongs = [
     artist: "ハチ",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 205,
     imageName:
       "6149b2a6a18ffcd54d9dd62c78bf408b4f9a896e2b111139a820c19498255748.png",
@@ -521,17 +521,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -543,7 +543,7 @@ const waccaSongs = [
     artist: "HARDCORE TANO*C & エリザベス（CV:大西沙織）",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 185,
     imageName:
       "15ac30127d43f254c69acdb4006d2823406f6bf04a08c95f924321e22a43b523.png",
@@ -552,22 +552,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -579,7 +579,7 @@ const waccaSongs = [
     artist: "土間うまる(田中あいみ)",
     dateAdded: 0,
     dateRemoved: 20210525,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 139,
     imageName:
       "e3bdf3f01cfc768d6d43f9da60fb65593a020136199557bd94c8f84f513cb6d5.png",
@@ -588,17 +588,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 5.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -610,7 +610,7 @@ const waccaSongs = [
     artist: "フランシュシュ",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 172,
     imageName:
       "5933e3ae26bc8de0b35882424d58420754de4f1138d9d5b031ef2427944e3324.png",
@@ -619,17 +619,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 6.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -641,7 +641,7 @@ const waccaSongs = [
     artist: "上坂すみれ",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 142,
     imageName:
       "5450cf5897236b06d8a1c13bfe2c25103837ac4d166c56faa91dbe52ecb5412b.png",
@@ -650,17 +650,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -672,7 +672,7 @@ const waccaSongs = [
     artist: "どうぶつビスケッツ×PPP",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 170,
     imageName:
       "2c2b26356dc6040bcf2060867c0ef2fffd12334698d6f39aab17ce89c15acb24.png",
@@ -681,17 +681,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -703,7 +703,7 @@ const waccaSongs = [
     artist: "みきとP",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 150,
     imageName:
       "5da980709d7792824a2a8c639722ec14f4b10b197a26815903aedc93c05aa520.png",
@@ -712,17 +712,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -734,7 +734,7 @@ const waccaSongs = [
     artist: "MONKEY MAJIK × サンドウィッチマン",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 116,
     imageName:
       "32917d692ff9dd99eb0a4a56c0d534b9598f7505726b60ecbe552f3f16fb9607.png",
@@ -743,17 +743,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 6.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -765,7 +765,7 @@ const waccaSongs = [
     artist: "BABYMETAL",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 220,
     imageName:
       "7ed03d81e2998cce63e37a29095d11633d34abf502a3c0a893e2e73650b7fb7e.png",
@@ -774,17 +774,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -796,7 +796,7 @@ const waccaSongs = [
     artist: "n-buna",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 120,
     imageName:
       "136a2809d31c8cf310aeca499734b1845505c8813e769b88b1efe6b98232bb7d.png",
@@ -805,17 +805,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -827,7 +827,7 @@ const waccaSongs = [
     artist: "GYARI(ココアシガレットP)",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 144,
     imageName:
       "f1c3d4420c3b83df5c82530cc22b643e81243d9f44ca7f8c61e0e7327f1fe422.png",
@@ -836,17 +836,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -858,7 +858,7 @@ const waccaSongs = [
     artist: "ぬゆり",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 127,
     imageName:
       "d577c6d3a3bd9454e38f4ae1aa2031344f37a217b1390ffab07c64f0b3c95735.png",
@@ -867,17 +867,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -889,7 +889,7 @@ const waccaSongs = [
     artist: "仁科カヅキ vs 大和アレクサンダー(増田俊樹・武内駿輔)",
     dateAdded: 0,
     dateRemoved: 20200717,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 144,
     imageName:
       "a5dcb041b9d58f166a5886c503c94fc9e210bddd805aef854400c2612d1ee8be.png",
@@ -898,17 +898,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -920,7 +920,7 @@ const waccaSongs = [
     artist: "ジョー・リノイエ with 安西美貴",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 165,
     imageName:
       "367ce305b3de8119e27fae674a8802f2a8552a1ddf9106e420bc589155b02d68.png",
@@ -929,17 +929,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 5.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -951,7 +951,7 @@ const waccaSongs = [
     artist: "REDALiCE",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 181,
     imageName:
       "e934eab848138ecfbcd45ef3633de5cac17ee44355dba4f621e8e3f123fc3c54.png",
@@ -960,17 +960,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -982,7 +982,7 @@ const waccaSongs = [
     artist: "t+pazolite",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 240,
     imageName:
       "307695dd3114ab48eb3fb0ccd85bfd1b00419863d5d165ce572ccbf9aa508094.png",
@@ -991,17 +991,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1013,7 +1013,7 @@ const waccaSongs = [
     artist: "DJ Noriken",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 170,
     imageName:
       "63b962eed9de8c738e483090bc5d93dde1af21cc300234eb4f9d86979f222fa8.png",
@@ -1022,22 +1022,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -1049,7 +1049,7 @@ const waccaSongs = [
     artist: "DJ Myosuke",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 200,
     imageName:
       "566d1da7e865ac875b081e48c895934296bfa8750e6bd141c8a857d8c89e50e3.png",
@@ -1058,22 +1058,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -1085,7 +1085,7 @@ const waccaSongs = [
     artist: "aran",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 180,
     imageName:
       "44c56f69eb010eab7e7dcb2d9e0b21f7b18eb71ac06a48068d5aa3e043082624.png",
@@ -1094,17 +1094,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1116,7 +1116,7 @@ const waccaSongs = [
     artist: "Getty",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 175,
     imageName:
       "9deaf9a7e3290ebb3641096e257af1c9431023b0fcf65f9bc32d4ae55a99e09f.png",
@@ -1125,17 +1125,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1147,7 +1147,7 @@ const waccaSongs = [
     artist: "Srav3R",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 175,
     imageName:
       "6c6be2066507003888dd9d5684fb0a3dd81832ad7a947ca3b7a61dacb8167459.png",
@@ -1156,17 +1156,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1178,7 +1178,7 @@ const waccaSongs = [
     artist: "DJ Genki VS かめりあ (feat. moimoi)",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 170,
     imageName:
       "1a14a7415c953ca5175b2eab1428f9aed6ffac1e88301b9a6e689581080ef721.png",
@@ -1187,17 +1187,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1209,7 +1209,7 @@ const waccaSongs = [
     artist: "USAO",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 170,
     imageName:
       "013f2aedc3dc32e6aeb4d4468732e84150d850d9611d4686497eea681c6a6ec8.png",
@@ -1218,17 +1218,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1240,7 +1240,7 @@ const waccaSongs = [
     artist: "Massive New Krew",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 150,
     imageName:
       "9af1419eeb415cc738765148dd9b62b87d26f221a61801aa974401f07fb9c647.png",
@@ -1249,17 +1249,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1271,7 +1271,7 @@ const waccaSongs = [
     artist: "P*Light feat. mow*2",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 170,
     imageName:
       "06c6518943f4563ec84038234c080eedb19587eb170748618b5cf681026848cd.png",
@@ -1280,17 +1280,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1302,7 +1302,7 @@ const waccaSongs = [
     artist: "源屋",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 175,
     imageName:
       "a1dbf65563d28ba47412b1e284a5426e75ee1f95f5efde1a4ba34864b6fc506c.png",
@@ -1311,17 +1311,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1333,7 +1333,7 @@ const waccaSongs = [
     artist: "Laur",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 190,
     imageName:
       "4970131765281eb0a6d8a0f4a2f483e7150dfddafdc14094475d7da01063a16a.png",
@@ -1342,22 +1342,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -1369,7 +1369,7 @@ const waccaSongs = [
     artist: "寺島拓篤",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 195,
     imageName:
       "054c088ad4a8c8f8760be35ad89f0d8e4752deb7483d2fc76ae0e2618a7bf2ce.png",
@@ -1378,17 +1378,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1400,7 +1400,7 @@ const waccaSongs = [
     artist: "Machico",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 134,
     imageName:
       "ea4fb881dfd779cb23419bfeb933d76f83df42586380c27ff35c6318e40bff95.png",
@@ -1409,17 +1409,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1432,7 +1432,7 @@ const waccaSongs = [
       "中野家の五つ子（花澤香菜・竹達彩奈・伊藤美来・佐倉綾音・水瀬いのり）",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 175,
     imageName:
       "c461d89a43d89f885f786acded6dc3345b7020d5dc91dd258b669ae3d0f196a7.png",
@@ -1441,17 +1441,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 6.1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1463,7 +1463,7 @@ const waccaSongs = [
     artist: "Yunomi",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 138,
     imageName:
       "1c1cbe5e109731d758c4d0446a5b20395d0cac85900384f696d346cf05839eaa.png",
@@ -1472,17 +1472,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1494,7 +1494,7 @@ const waccaSongs = [
     artist: "新庄かなえ（三森すずこ）",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 160,
     imageName:
       "11a978dadb99ca5c94a5c464c25ed7191c04a6ef2495a86aa957a9f381a12483.png",
@@ -1503,17 +1503,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1525,7 +1525,7 @@ const waccaSongs = [
     artist: "DECO*27",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 134,
     imageName:
       "0bbc0279d0bef8e6a9f65502eb43dd6f05e9a3f3404f5aa48812498f1d3be31e.png",
@@ -1534,17 +1534,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1556,7 +1556,7 @@ const waccaSongs = [
     artist: "DECO*27",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 150,
     imageName:
       "e82b473cead728daad379bee51c2f8e6b3047857674d5cc28aaf15d20b2d6177.png",
@@ -1565,17 +1565,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1587,7 +1587,7 @@ const waccaSongs = [
     artist: "Harmonies(P*Light & Massive New Krew)",
     dateAdded: 0,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 150,
     imageName:
       "0ceae99280ec30dae5d45a85f39f31391b454c7526bc946c15c5c3a59a125e25.png",
@@ -1596,17 +1596,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1618,7 +1618,7 @@ const waccaSongs = [
     artist: "DJ Noriken",
     dateAdded: 20190801,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 170,
     imageName:
       "7ab27d493cb338454cd63cea8926185ebcf69c5cd90c0d53f04079129979e739.png",
@@ -1627,17 +1627,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1649,7 +1649,7 @@ const waccaSongs = [
     artist: "aran",
     dateAdded: 20190801,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 174,
     imageName:
       "0533222b804bdc385aea9ef7f7577608119ac7f8c0cdc45f1b9488c6019c0fc5.png",
@@ -1658,17 +1658,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1680,7 +1680,7 @@ const waccaSongs = [
     artist: "siromaru + cranky",
     dateAdded: 20190801,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 160,
     imageName:
       "131df2951b9b7c742b3df4281d29418150fd7d3fa2aff80fe6d3bf8f3f11b674.png",
@@ -1689,17 +1689,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1711,7 +1711,7 @@ const waccaSongs = [
     artist: "TANO*C Sound Team",
     dateAdded: 20190801,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 200,
     imageName:
       "4189c1a52e4f9a4a611757eadef1866f358b3f165375a7c67d5f8d88247c0736.png",
@@ -1720,22 +1720,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 14.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -1747,7 +1747,7 @@ const waccaSongs = [
     artist: "ARuFa",
     dateAdded: 20190801,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 168,
     imageName:
       "2c52485cf60072d6383faf9a4520dbe7e7796c91ee025630d423aca73cb4e27c.png",
@@ -1756,17 +1756,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1778,7 +1778,7 @@ const waccaSongs = [
     artist: "ARuFa & t+pazolite & かめりあ",
     dateAdded: 20190801,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 205,
     imageName:
       "b9f34c06376e97f16ad2fd15e922bd1b08407f6ecfc8c7db99f8df7c9a49f72e.png",
@@ -1787,22 +1787,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -1814,7 +1814,7 @@ const waccaSongs = [
     artist: "三浦大知",
     dateAdded: 20190815,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 151,
     imageName:
       "a8d086c533f5ea9b44008a5f8617f9b869c5076cd3f610acf4dae86f458d1211.png",
@@ -1823,17 +1823,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 6.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1845,7 +1845,7 @@ const waccaSongs = [
     artist: "Laur",
     dateAdded: 20190815,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 260,
     imageName:
       "36ac5b48792c713640ace2a93cd6702db1d6e9b2d1c8fea17f7528d8df168dd1.png",
@@ -1854,17 +1854,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 14.1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1876,7 +1876,7 @@ const waccaSongs = [
     artist: "Getty",
     dateAdded: 20190815,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 170,
     imageName:
       "368703e2e31c7754e99d0a457926ef1952ed19412fa4ee3d7a6fb1c73774a763.png",
@@ -1885,17 +1885,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -1907,7 +1907,7 @@ const waccaSongs = [
     artist: "うたたP",
     dateAdded: 20190815,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 142,
     imageName:
       "cb0af66a359c85a13f346a7fc1f3b21b40f58753ba3389a1c8520f392976441a.png",
@@ -1916,22 +1916,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 1,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "DO YOU REMEMBER THE CODE? [ 覚 ]",
       },
     ],
@@ -1943,7 +1943,7 @@ const waccaSongs = [
     artist: "DJ Genki",
     dateAdded: 20190905,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 170,
     imageName:
       "d88f295f50619748777e2175a9f5c3bba382a23d06bb9ebb42a94b3b76ebabc8.png",
@@ -1952,22 +1952,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Eulogy of a Dandel1on",
       },
     ],
@@ -1979,7 +1979,7 @@ const waccaSongs = [
     artist: "Massive New Krew",
     dateAdded: 20190905,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 155,
     imageName:
       "8c0b9c0ff0a2ac7cfa48fc12f1aeb33c2da622b128928a05860ee6f3a6a3fd05.png",
@@ -1988,17 +1988,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2010,7 +2010,7 @@ const waccaSongs = [
     artist: "P*Light",
     dateAdded: 20190905,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 200,
     imageName:
       "29e219426a1eb2a821b013bc7d2588bc1246fa17b687161e4cc12e7201a772dc.png",
@@ -2019,17 +2019,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2041,7 +2041,7 @@ const waccaSongs = [
     artist: "REDALiCE",
     dateAdded: 20190905,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 169,
     imageName:
       "2f0a36f0ad5881d81e36f0c0cca67c3409de2e719da3a97576ccf372fa277b50.png",
@@ -2050,22 +2050,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "REiEZU vs やくさんす？",
       },
     ],
@@ -2077,7 +2077,7 @@ const waccaSongs = [
     artist: "DJ Myosuke",
     dateAdded: 20190905,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 190,
     imageName:
       "c4f828b9d77924f8c3608a12673c53502273d02277672f792a372a5c3de4c34a.png",
@@ -2086,17 +2086,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2108,7 +2108,7 @@ const waccaSongs = [
     artist: "八王子P",
     dateAdded: 20190919,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 160,
     imageName:
       "ba9616c4027cf4d4cb37be9b7fcbdb9889a48eb6465a18199435e897c85b654a.png",
@@ -2117,17 +2117,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2139,7 +2139,7 @@ const waccaSongs = [
     artist: "ナユタン星人",
     dateAdded: 20190919,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 150,
     imageName:
       "2fea6352ef78d3a2b45adb37368789b2a83a7441b4378dd1a4922a86ec4c1572.png",
@@ -2148,17 +2148,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2170,7 +2170,7 @@ const waccaSongs = [
     artist: "GYARI(ココアシガレットP)",
     dateAdded: 20190919,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 136,
     imageName:
       "36ffc2eae3d5057d77ad5d849de002a0bf26d776ef5911bfc8adc53f0ca8e099.png",
@@ -2179,17 +2179,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2201,7 +2201,7 @@ const waccaSongs = [
     artist: "Srav3R",
     dateAdded: 20190919,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 180,
     imageName:
       "2653163e34cf97e90f1ed803790a8380e1aef3bfb31aab11b94d31796054fca2.png",
@@ -2210,17 +2210,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2232,7 +2232,7 @@ const waccaSongs = [
     artist: "Kobaryo",
     dateAdded: 20190919,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 300,
     imageName:
       "478a03461af30bef87684403310ffede8c770b0d9ed2a4f9061b59b3e357e650.png",
@@ -2241,17 +2241,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2263,7 +2263,7 @@ const waccaSongs = [
     artist: "Masayoshi Minoshima",
     dateAdded: 20191010,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 138,
     imageName:
       "f718ec596f26ef6dceede2bd2ed61a610c8910dbb28ef37e3bfb16c0add0ad24.png",
@@ -2272,17 +2272,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 5.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2294,7 +2294,7 @@ const waccaSongs = [
     artist: "ビートまりお（COOL&CREATE）",
     dateAdded: 20191010,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 180,
     imageName:
       "10d5995f636155cd21e276273a7deaaa8ce1c0325f4016690cb1f16764b1fbf9.png",
@@ -2303,17 +2303,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2325,7 +2325,7 @@ const waccaSongs = [
     artist: "暁Records",
     dateAdded: 20191010,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 172,
     imageName:
       "7ed127f09d936503213429c69247290b1efe118c701901d14d3084f4fe651215.png",
@@ -2334,17 +2334,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2356,7 +2356,7 @@ const waccaSongs = [
     artist: "亜咲花",
     dateAdded: 20191010,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 143,
     imageName:
       "d4f001eccf01bb8d77a9e0114770afc4ba3d17fe7e272824d256c50ba7cf0850.png",
@@ -2365,17 +2365,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2387,7 +2387,7 @@ const waccaSongs = [
     artist: "亜咲花",
     dateAdded: 20191010,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 110,
     imageName:
       "0cbff660a545a64824d241939ca3c40e0f2a0c0e8a2205d4bbf788200ddef641.png",
@@ -2396,17 +2396,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 5.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2418,7 +2418,7 @@ const waccaSongs = [
     artist: "飛鳥(原田ひとみ)・焔(喜多村英梨)・雅緋(平田宏美)・雪泉(原由実)",
     dateAdded: 20191017,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 134,
     imageName:
       "14446cbb8dbf5f02b501ddddea72bdc775eaf3b28efc9fc183b3c11179cf4539.png",
@@ -2427,17 +2427,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 6.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2449,7 +2449,7 @@ const waccaSongs = [
     artist: "ARM＋夕野ヨシミ (IOSYS) feat. miko",
     dateAdded: 20191017,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 175,
     imageName:
       "e0f2bf3f479be1a263827925014d583337091d26bf2cd09adbc476e2e1e15286.png",
@@ -2458,17 +2458,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2480,7 +2480,7 @@ const waccaSongs = [
     artist: "REDALiCE",
     dateAdded: 20191017,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 180,
     imageName:
       "8d97e8a4a3fc3e4e2f693ce42cba7811ac728441bf57159d0a70e4d6d8d696d5.png",
@@ -2489,17 +2489,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2511,7 +2511,7 @@ const waccaSongs = [
     artist: "豚乙女",
     dateAdded: 20191017,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 160,
     imageName:
       "d2571510951af6d68175d6ce7587282da5a807c47b1c12377569d3cc5090fd4b.png",
@@ -2520,17 +2520,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 6.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2542,7 +2542,7 @@ const waccaSongs = [
     artist: "USAO",
     dateAdded: 20191031,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 128,
     imageName:
       "2a0f7c7db09712917fd4bd5b57130745e6f7a05988f77c5cf4195bdf7e1ecd5e.png",
@@ -2551,17 +2551,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2573,7 +2573,7 @@ const waccaSongs = [
     artist: "W&W ft. Kizuna AI",
     dateAdded: 20191031,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 160,
     imageName:
       "ed9d3e586ac7c48e6998376589554fe7b0fd873eb55035fff689cdac5f0fa35e.png",
@@ -2582,17 +2582,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2604,7 +2604,7 @@ const waccaSongs = [
     artist: "Kizuna AI",
     dateAdded: 20191031,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 128,
     imageName:
       "6894935c7ca7b4feecaeea03bf48fde6e0d1d732a05491515df038dad21b6455.png",
@@ -2613,17 +2613,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 6.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2635,7 +2635,7 @@ const waccaSongs = [
     artist: "Kizuna AI",
     dateAdded: 20191031,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 160,
     imageName:
       "d0f1bae67c92c497ced75ab2e038a88c6bf8e8821266ddc44637ffaa826fc088.png",
@@ -2644,17 +2644,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2666,7 +2666,7 @@ const waccaSongs = [
     artist: "ヨルシカ",
     dateAdded: 20191114,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 140,
     imageName:
       "422483e1ff106b9567a83d1d1694514c14f56e26da35327b238e334d1f237732.png",
@@ -2675,17 +2675,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2697,7 +2697,7 @@ const waccaSongs = [
     artist: "t+pazolite",
     dateAdded: 20191114,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 200,
     imageName:
       "b322fee1ba75240bc288cdb59a07741dffd13117d3942589b6f73524e03e7bb8.png",
@@ -2706,17 +2706,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2728,7 +2728,7 @@ const waccaSongs = [
     artist: "高橋洋子",
     dateAdded: 20191114,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 129,
     imageName:
       "5a38994ba55318aeb657d88856678385b93fe3579ba1e6d4a3d35cbf558566d5.png",
@@ -2737,17 +2737,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 5.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2759,7 +2759,7 @@ const waccaSongs = [
     artist: "Snail's House",
     dateAdded: 20191114,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 150,
     imageName:
       "75d98280f93128ba0543c04f3fbae54fa0d58896291352ffed124ae739d152e8.png",
@@ -2768,17 +2768,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2790,7 +2790,7 @@ const waccaSongs = [
     artist: "HiTECH NINJA",
     dateAdded: 20191114,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 165,
     imageName:
       "d6693ab94ed95031b65e2a596f1aa4de301ecdf2be17ff6aa4f21649d638fa50.png",
@@ -2799,22 +2799,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "fraudulentRAV#R",
       },
     ],
@@ -2826,7 +2826,7 @@ const waccaSongs = [
     artist: "YURI!!! on ICE feat. w.hatano",
     dateAdded: 20191128,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 126,
     imageName:
       "8bf230313591d3a7df7cc09fbfa5424fef32a0722dc066b3dd81a5067da481bb.png",
@@ -2835,17 +2835,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 5.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2857,7 +2857,7 @@ const waccaSongs = [
     artist: "土間うまる(田中あいみ)",
     dateAdded: 20191128,
     dateRemoved: 20210525,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 170,
     imageName:
       "e557c85412a83d4ccfe6dfb58ebe2811928d7f094da26403a9931077b9a01584.png",
@@ -2866,17 +2866,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2888,7 +2888,7 @@ const waccaSongs = [
     artist: "Giga feat. 鏡音リン・レン",
     dateAdded: 20191128,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 160,
     imageName:
       "5e69174847bb2c2e26c3dade7b8a7f9fd98fcacbf899370f3d482a2ebfa9e38e.png",
@@ -2897,22 +2897,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
 	  {
         difficulty: 13.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Lightning Sword vs 深红鬼",
       },
     ],
@@ -2924,7 +2924,7 @@ const waccaSongs = [
     artist: "C-Show",
     dateAdded: 20191128,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 175,
     imageName:
       "25177669afc4cfac15f372a6d7d3f8abd9a58dcd925c135b15b01a716cbf491f.png",
@@ -2933,22 +2933,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "YUKIDAMA",
       },
     ],
@@ -2960,7 +2960,7 @@ const waccaSongs = [
     artist: "KO3&Relect",
     dateAdded: 20191128,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 190,
     imageName:
       "65116708a74ec68c67fc3158e7336e73c5c06ccfccfe51353b0ce77c842b2b23.png",
@@ -2969,17 +2969,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -2991,7 +2991,7 @@ const waccaSongs = [
     artist: "cosMo@暴走P",
     dateAdded: 20191212,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 240,
     imageName:
       "8f552e76c1c52e461a2b5e1dc62cb44ef55cf2baa8007f99478a037cabe91685.png",
@@ -3000,17 +3000,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -3022,7 +3022,7 @@ const waccaSongs = [
     artist: "Kobaryo",
     dateAdded: 20191212,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 245,
     imageName:
       "8c29e74a237df05ce701bec384f9a7f589546e1fc75a0df6afb53cb87527aed5.png",
@@ -3031,17 +3031,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 14,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -3053,7 +3053,7 @@ const waccaSongs = [
     artist: "xi",
     dateAdded: 20191212,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 222,
     imageName:
       "24b298ad97f0f60be0fc4ffc4db800d6c540672d23b4d89918cbda208e31ffaa.png",
@@ -3062,17 +3062,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -3084,7 +3084,7 @@ const waccaSongs = [
     artist: "Da Tweekaz",
     dateAdded: 20191224,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 150,
     imageName:
       "35e4385a02785f265a3c9d707baa84e69e491ed33f8eb796c284498b47239425.png",
@@ -3093,17 +3093,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 8.8,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 11.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -3115,7 +3115,7 @@ const waccaSongs = [
     artist: "エキセントリック少年ボウイ　オールスターズ",
     dateAdded: 20191224,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 150,
     imageName:
       "8e3d7c4281470e6ca72ac904d2769104223ddac9745415a59cf190eaa7ab23a9.png",
@@ -3124,17 +3124,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 5.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -3146,7 +3146,7 @@ const waccaSongs = [
     artist: "超魂團（ウルトラソウルズ）",
     dateAdded: 20191224,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 200,
     imageName:
       "6730d2b544ba7292b94436857766e119f3da5b9f615b81e1d24621a49721e348.png",
@@ -3155,17 +3155,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 6.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -3177,7 +3177,7 @@ const waccaSongs = [
     artist: "DJ Myosuke & Gram",
     dateAdded: 20191224,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 222,
     imageName:
       "ecf4de3d02f5c8df7adbb23aa2fa0676ea41736b49355b24a33a1960bb3b964c.png",
@@ -3186,17 +3186,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 13.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -3208,7 +3208,7 @@ const waccaSongs = [
     artist: "舞台『弱虫ペダル』キャスト",
     dateAdded: 20191224,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 160,
     imageName:
       "951277121b4ae791018224327606caa7cc3b5487bf98d546f5dcd958a5988b14.png",
@@ -3217,17 +3217,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 5.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -3239,7 +3239,7 @@ const waccaSongs = [
     artist: "西村 隆文",
     dateAdded: 20200109,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 187,
     imageName:
       "bf69d7cf45e7968699a93bf93ba8f2fd58fdf8f97194efd06b6552c40fafe4d8.png",
@@ -3248,17 +3248,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 9.3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -3270,7 +3270,7 @@ const waccaSongs = [
     artist: "COSIO",
     dateAdded: 20200109,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 182,
     imageName:
       "791b604bcb3177e2b98eef71e512b9b00853653640332e8c7c142ef4256e3caa.png",
@@ -3279,17 +3279,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 7.2,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.9,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -3301,7 +3301,7 @@ const waccaSongs = [
     artist: "Getty",
     dateAdded: 20200109,
     dateRemoved: 0,
-    gameVersion: 1,
+    gameVersion: 100,
     bpm: 170,
     imageName:
       "0ae4d790692382c32b10546a3574bf636808155f907fae84af96aa16a162046d.png",
@@ -3310,17 +3310,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 10,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 1,
+        gameVersion: 100,
         charter: "Marvelous",
       },
     ],
@@ -3332,7 +3332,7 @@ const waccaSongs = [
     artist: "fripSide",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 143,
     imageName:
       "bc91c26599c06799a87e3e41968859df174a00c984d969d2f85e07ec65a70297.png",
@@ -3341,17 +3341,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 6.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3363,7 +3363,7 @@ const waccaSongs = [
     artist: "DECO*27",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 210,
     imageName:
       "2702631eaedefaa773b957ab45af5088298966f590f27db6889494a46b04f7ae.png",
@@ -3372,17 +3372,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 11.6,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3394,7 +3394,7 @@ const waccaSongs = [
     artist: "USAO & DJ Genki",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 190,
     imageName:
       "39d7ad009113ebe6b8ef6b70b7cd12f32dac7003e891c5201abdb379ea7f2a36.png",
@@ -3403,17 +3403,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.8,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3425,7 +3425,7 @@ const waccaSongs = [
     artist: "フレデリック",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 172,
     imageName:
       "77f3c132935e0c269f3c2832627de539eb1d5bac0ed81f7bb4327e2c084f7361.png",
@@ -3434,17 +3434,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.9,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3456,7 +3456,7 @@ const waccaSongs = [
     artist: "飛鳥(原田ひとみ)&焔(喜多村英梨)",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 195,
     imageName:
       "bb8db03c48091e08a14eadaf317f321589314c4f58000520dbbfb40eeb26bdd3.png",
@@ -3465,17 +3465,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 11.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3487,7 +3487,7 @@ const waccaSongs = [
     artist: "Neru",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 162,
     imageName:
       "cdd148c656d97ec961c67737f6df6d71eb2c98153b5072a63fb98281e330f98d.png",
@@ -3496,17 +3496,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 8.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3518,7 +3518,7 @@ const waccaSongs = [
     artist: "みきとP",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 145,
     imageName:
       "0e4da16d6c06fb74b158466c078b415c7307dfbc62a01580cdc601c906ac0c6d.png",
@@ -3527,17 +3527,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 6.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3549,7 +3549,7 @@ const waccaSongs = [
     artist: "森羅万象",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 192,
     imageName:
       "f949a370369896f25ea5ec37841c18b1a5c8cf079ff6feedd52d28eed4dfd40f.png",
@@ -3558,17 +3558,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 8.6,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3580,7 +3580,7 @@ const waccaSongs = [
     artist: "REDALiCE feat. 野宮あゆみ",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 173,
     imageName:
       "116692ac76bc1d374cdce73548f4ae00fb812b41c06075a2f85cbec69e6e3df7.png",
@@ -3589,17 +3589,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 11.4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3611,7 +3611,7 @@ const waccaSongs = [
     artist: "Hommarju",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 170,
     imageName:
       "fe32b8cdbd5578f67366f258ef9c862637a34fcf2d85d27678c19ba541b67f2b.png",
@@ -3620,17 +3620,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.8,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3642,7 +3642,7 @@ const waccaSongs = [
     artist: "Srav3R",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 180,
     imageName:
       "7786d2552f5068ec96d68f7f10e1a77e12d9f3aa8845a5a53eb2269fa209e27b.png",
@@ -3651,17 +3651,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3673,7 +3673,7 @@ const waccaSongs = [
     artist: "aran",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 155,
     imageName:
       "303af6aa5d0c435a5964bccb34c23b01755e38417586737b17df98e1f1281a7c.png",
@@ -3682,17 +3682,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.8,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3704,7 +3704,7 @@ const waccaSongs = [
     artist: "Eve",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 149,
     imageName:
       "0672d2dfef5412f5868e0e707a95262319bf550954c2696819b60f7bb75eb288.png",
@@ -3713,17 +3713,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3735,7 +3735,7 @@ const waccaSongs = [
     artist: "かめりあ",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 188,
     imageName:
       "465b94ca3cde7913410c9b612a9153be42ab4e47871060cc29986d265512b57d.png",
@@ -3744,17 +3744,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 13.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3766,7 +3766,7 @@ const waccaSongs = [
     artist: "Kobaryo",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 200,
     imageName:
       "197be068231fbdaea7022d5de96fb6e28d910923033af5024a855984893e2e60.png",
@@ -3775,17 +3775,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 13.6,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3797,7 +3797,7 @@ const waccaSongs = [
     artist: "Massive New Krew",
     dateAdded: 20200123,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 150,
     imageName:
       "7048d6d5c17d9bdf243a02498e9abb41f4b984dc2d4c25b0545051232e1f3c79.png",
@@ -3806,17 +3806,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 8.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 11.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3828,7 +3828,7 @@ const waccaSongs = [
     artist: "かめりあ feat. ななひら",
     dateAdded: 20200206,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 128,
     imageName:
       "4926d0164c88a89b2be9c2664987bdd216438caeb844fb5394bc713891edcbc5.png",
@@ -3837,17 +3837,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.9,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3859,7 +3859,7 @@ const waccaSongs = [
     artist: "E.G.G. a.k.a. COSIO",
     dateAdded: 20200206,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 260,
     imageName:
       "ceafb0be7a84719a384db96f857e64efa21c1087e8bbe728ce5e3716d2a8b09c.png",
@@ -3868,17 +3868,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3890,7 +3890,7 @@ const waccaSongs = [
     artist: "バルーン",
     dateAdded: 20200206,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 145,
     imageName:
       "953d656957865589aa421cb04a68ebff4a8529e1bc3d9a3c535eb34524414543.png",
@@ -3899,17 +3899,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3921,7 +3921,7 @@ const waccaSongs = [
     artist: "hololive IDOL PROJECT",
     dateAdded: 20200213,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 168,
     imageName:
       "ae8e0747f2837d8ad73a3bb4831118c14624533d8a26e40d4d2eab54808e8c85.png",
@@ -3930,17 +3930,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 6.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3952,7 +3952,7 @@ const waccaSongs = [
     artist: "ときのそら",
     dateAdded: 20200213,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 136,
     imageName:
       "22da1c7d12b2528557d21c44b0bb220ba2006479cafc916ddda82d8ca8f113ab.png",
@@ -3961,17 +3961,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 11.2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -3983,7 +3983,7 @@ const waccaSongs = [
     artist: "AZKi",
     dateAdded: 20200213,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 173,
     imageName:
       "8bb9ce616d23b7e17b189ceddc4813cab9b3b6344b85051a769cbdd5614e223f.png",
@@ -3992,17 +3992,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4014,7 +4014,7 @@ const waccaSongs = [
     artist: "サカナクション",
     dateAdded: 20200220,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 157,
     imageName:
       "648a5a29830f678641998519a271946af859542e4ca951d356740e6535d40eaa.png",
@@ -4023,17 +4023,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 6.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4045,7 +4045,7 @@ const waccaSongs = [
     artist: "DA PUMP",
     dateAdded: 20200220,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 140,
     imageName:
       "d9c0dad6795eb91bea7297206aa65b6b66c61343b2797c8d920da9603536b91c.png",
@@ -4054,17 +4054,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4076,7 +4076,7 @@ const waccaSongs = [
     artist: "Last Note.",
     dateAdded: 20200227,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 145,
     imageName:
       "fd61222762004e6a4d5557c19dc5b62c908932d07198999f1ddbbfa87a109544.png",
@@ -4085,17 +4085,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4107,7 +4107,7 @@ const waccaSongs = [
     artist: "じん(自然の敵P)",
     dateAdded: 20200227,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 200,
     imageName:
       "5f116745b811923ea48ed2ccb6be0ad4dc4fd48df6cd590e5270c5de4b348c18.png",
@@ -4116,17 +4116,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 11.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4138,7 +4138,7 @@ const waccaSongs = [
     artist: "164",
     dateAdded: 20200227,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 200,
     imageName:
       "a42918eaa6b904d88ed07a730d2a78fb75201f816b0d647ad12748f1ccd8cf29.png",
@@ -4147,17 +4147,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4169,7 +4169,7 @@ const waccaSongs = [
     artist: "Silver Forest",
     dateAdded: 20200305,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 172,
     imageName:
       "dbf83efa1c92cbaf22494a671c5b9d93830647bb990688d07f848c7c9b19243f.png",
@@ -4178,17 +4178,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 6.2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 11.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4200,7 +4200,7 @@ const waccaSongs = [
     artist: "暁Records",
     dateAdded: 20200305,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 168,
     imageName:
       "efe74b622b89d96268eeb6284f8b61dc304d67677471a6caf64150e6d294dfee.png",
@@ -4209,17 +4209,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4231,7 +4231,7 @@ const waccaSongs = [
     artist: "魂音泉",
     dateAdded: 20200305,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 160,
     imageName:
       "d12cbc6fb3c8d9476a5f1a17a921aa5e631a1fcfab931973534b33865d287908.png",
@@ -4240,17 +4240,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 8.2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4262,7 +4262,7 @@ const waccaSongs = [
     artist: "t+pazolite",
     dateAdded: 20200305,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 180,
     imageName:
       "16c3b45f05b64292b5fc3a018f8a800402353f710667541a93b163f1488dd187.png",
@@ -4271,17 +4271,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.8,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 13.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4293,7 +4293,7 @@ const waccaSongs = [
     artist: "豚乙女",
     dateAdded: 20200305,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 188,
     imageName:
       "50765ed6497fda9abc5bc7905717f8d1ac69f72d0e1ebb6e024be95732f15bda.png",
@@ -4302,17 +4302,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4324,7 +4324,7 @@ const waccaSongs = [
     artist: "onoken",
     dateAdded: 20200319,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 175,
     imageName:
       "eb96d2b51c8d3c752f1b9713b024f7e985b79632e8cc3c89a4f1173abf6f6a7a.png",
@@ -4333,17 +4333,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4355,7 +4355,7 @@ const waccaSongs = [
     artist: "Laur",
     dateAdded: 20200319,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 110,
     imageName:
       "d160524e48855ddcc43894a34e50aed9e55ea7e693b66095818381548837f855.png",
@@ -4364,17 +4364,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.8,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4386,7 +4386,7 @@ const waccaSongs = [
     artist: "まふまふ",
     dateAdded: 20200326,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 196,
     imageName:
       "df1983d7ea1b51a9f6323d79c76d2647299f4ef63b9c68256ac2ea4d812fa919.png",
@@ -4395,17 +4395,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4417,7 +4417,7 @@ const waccaSongs = [
     artist: "岸田教団&THE明星ロケッツ",
     dateAdded: 20200326,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 208,
     imageName:
       "501fdff9243aa75cac141672e5f46de39cabab24ae13744262fa859c92815952.png",
@@ -4426,17 +4426,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 11.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4448,7 +4448,7 @@ const waccaSongs = [
     artist: "PSYQUI",
     dateAdded: 20200402,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 168,
     imageName:
       "72d13eae7b726fa7fe863573eb55380a5750eb03c1e349056dad1bbe8cae5611.png",
@@ -4457,17 +4457,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4479,7 +4479,7 @@ const waccaSongs = [
     artist: "EBIMAYO",
     dateAdded: 20200402,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 165,
     imageName:
       "9143e3645ec7e8ce8e05240afa35a2518a2c426788d8cae143e409a2db560180.png",
@@ -4488,17 +4488,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4510,7 +4510,7 @@ const waccaSongs = [
     artist: "削除",
     dateAdded: 20200402,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 90,
     imageName:
       "e196c34954f4f3a0a7dec5affbafd05d5da2b6f0027c0f7bac2c7e7bb223f798.png",
@@ -4519,17 +4519,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4541,7 +4541,7 @@ const waccaSongs = [
     artist: "セイネ (CV: 河上英里子) 「グルーヴコースター」より",
     dateAdded: 20200409,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 178,
     imageName:
       "ee2a09b0c18b4ae055de12207edf07733c99e6c931fe416ee499a66d6a8c3a2d.png",
@@ -4550,17 +4550,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 8.2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4572,7 +4572,7 @@ const waccaSongs = [
     artist: "COSIO (ZUNTATA) 「グルーヴコースター」より",
     dateAdded: 20200409,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 192,
     imageName:
       "8b03620d396f026e373fe4dda7dd0c0f74909a259a7a85c84d16f46edaad8178.png",
@@ -4581,17 +4581,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.8,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 13.6,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4603,7 +4603,7 @@ const waccaSongs = [
     artist: "世阿弥 「グルーヴコースター」より",
     dateAdded: 20200416,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 169,
     imageName:
       "232a18d1c34dfdf2665a914b778475ecee4e457de90e810228fcb3b3274f1e3c.png",
@@ -4612,17 +4612,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.6,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4634,7 +4634,7 @@ const waccaSongs = [
     artist: "REDALiCE vs MASAKI 「グルーヴコースター」より",
     dateAdded: 20200416,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 200,
     imageName:
       "82cfabc2d2dc1841dfba08633859bca27ef67d776dfbee215b4c1f192862dbba.png",
@@ -4643,17 +4643,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 13.9,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4665,7 +4665,7 @@ const waccaSongs = [
     artist: "NOMA",
     dateAdded: 20200618,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 170,
     imageName:
       "34dad32f9e7263757f18e2c19864cce166601d737ebd18348d6983b749745976.png",
@@ -4674,17 +4674,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 13,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4696,7 +4696,7 @@ const waccaSongs = [
     artist: "REDALiCE & Hommarju",
     dateAdded: 20200618,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 170,
     imageName:
       "fdb101888910354d32532dece3276e46e0e5da79d8e6cd530c6d7ebed0acf15c.png",
@@ -4705,17 +4705,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.6,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.8,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4727,7 +4727,7 @@ const waccaSongs = [
     artist: "葛西ハーコーズ",
     dateAdded: 20200618,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 175,
     imageName:
       "c005d0b36abf43ff96477c5263e8ee2ea41b8df40944b46fd2e8e1fc15b74e4c.png",
@@ -4736,17 +4736,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 13.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4758,7 +4758,7 @@ const waccaSongs = [
     artist: "ミュージカル『テニスの王子様』3rdシーズン",
     dateAdded: 20200702,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 134,
     imageName:
       "b6c0b25c6de057936565d44d794d21125117442f81def9a09a47e772c147ac11.png",
@@ -4767,17 +4767,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 6,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4789,7 +4789,7 @@ const waccaSongs = [
     artist: "ミュージカル『テニスの王子様』3rdシーズン",
     dateAdded: 20200702,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 155,
     imageName:
       "d83a36cb7a6881a5572704edd104aa2f51a1c7754643c4fe397c69c1f42b5ee6.png",
@@ -4798,17 +4798,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 6.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4820,7 +4820,7 @@ const waccaSongs = [
     artist: "ミュージカル『テニスの王子様』3rdシーズン",
     dateAdded: 20200702,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 155,
     imageName:
       "990408afa009efba27595caf828f8739d4c01dd73797eccaf897ab39d412669d.png",
@@ -4829,17 +4829,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4851,7 +4851,7 @@ const waccaSongs = [
     artist: "ブレンド・A",
     dateAdded: 20200709,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 152,
     imageName:
       "31c73de24a61376ec89dbf5c3edaebed1849627710a9436da995db82c310d0a4.png",
@@ -4860,17 +4860,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 11.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4882,7 +4882,7 @@ const waccaSongs = [
     artist: "ブレンド・A",
     dateAdded: 20200709,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 164,
     imageName:
       "569fc916713567ca354dcbdef1250ba20c98b68e7a43013e74778da88e4f460e.png",
@@ -4891,17 +4891,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 5.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4913,7 +4913,7 @@ const waccaSongs = [
     artist: "cosMo@暴走P",
     dateAdded: 20200723,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 232,
     imageName:
       "055f13a2529854cc1dfdbaf0f9d076008c8d196aa78dffe184052d5ab1a088bc.png",
@@ -4922,17 +4922,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4944,7 +4944,7 @@ const waccaSongs = [
     artist: "和田たけあき(くらげP)",
     dateAdded: 20200723,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 220,
     imageName:
       "0c8a7dc0680f1d2767bdf4a89d7ba084dc228c5f2e6b7e7a3de555258e45d415.png",
@@ -4953,17 +4953,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 8.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -4975,7 +4975,7 @@ const waccaSongs = [
     artist: "ピノキオピー",
     dateAdded: 20200723,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 148,
     imageName:
       "8fa2a8e85b660759a0ef0538a56ad189e58213956c0ca8898fede41330e5fb6a.png",
@@ -4984,17 +4984,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 8,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 11.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -5006,7 +5006,7 @@ const waccaSongs = [
     artist: "かいりきベア",
     dateAdded: 20200723,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 152,
     imageName:
       "e25c0c3f35b9ef2317e607b2818781a0d7970a618d689de6184494e71385fcca.png",
@@ -5015,17 +5015,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -5037,7 +5037,7 @@ const waccaSongs = [
     artist: "Laur",
     dateAdded: 20200806,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 160,
     imageName:
       "5f0a5d71448b760ef250e3471845af9d29b0e492b35fb40f4c92056ce6c2731e.png",
@@ -5046,22 +5046,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 13.9,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "kitsura",
       },
     ],
@@ -5073,7 +5073,7 @@ const waccaSongs = [
     artist: "DJ Noriken",
     dateAdded: 20200806,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 198,
     imageName:
       "d6cf229550efccb6c90df34d48f28a21c4891f5218d3bef5de4c18b79d66b689.png",
@@ -5082,17 +5082,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 13.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -5104,7 +5104,7 @@ const waccaSongs = [
     artist: "Getty",
     dateAdded: 20200806,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 200,
     imageName:
       "9acb5bd894388ce400d32102395861f85b89bc10efd2f29bbe4dce9693e1978b.png",
@@ -5113,17 +5113,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -5135,7 +5135,7 @@ const waccaSongs = [
     artist: "USAO",
     dateAdded: 20200806,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 205,
     imageName:
       "06b44e158a7dbf4e88362760b93b38aab1907e090b7fabd3e0a5fdaad5d38b68.png",
@@ -5144,22 +5144,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.9,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 14,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -5171,7 +5171,7 @@ const waccaSongs = [
     artist: "REDALiCE & cosMo＠暴走P",
     dateAdded: 20200806,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 203,
     imageName:
       "9aa7ee0b336353c9dd98ec3737c25236c8431d5b37fbf7a575e695c1fbd1b0bd.png",
@@ -5180,22 +5180,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 13.2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 14.1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -5207,7 +5207,7 @@ const waccaSongs = [
     artist: "C-Show",
     dateAdded: 20200806,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 108,
     imageName:
       "3998c81dab18ddebf2fc73700301077b137c68bc7420595bfd0a7a33c508906a.png",
@@ -5216,17 +5216,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.4,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -5238,7 +5238,7 @@ const waccaSongs = [
     artist: "fhána",
     dateAdded: 20200820,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 135,
     imageName:
       "ef2e0f4cc10c43b8e764a9bc394f2391860cfebb2984d8b58f214b8465c87e53.png",
@@ -5247,22 +5247,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 6.8,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -5274,7 +5274,7 @@ const waccaSongs = [
     artist: "ナナヲアカリ",
     dateAdded: 20200820,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 180,
     imageName:
       "ec99c9063fee60a9165355d29bb87e67aeb860bf15e96e7287b9635f7d584dee.png",
@@ -5283,17 +5283,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.8,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 12,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -5305,7 +5305,7 @@ const waccaSongs = [
     artist: "Lia",
     dateAdded: 20200820,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 152,
     imageName:
       "2aaec1397b9538c515da9f49962658f8ecec01a8ef0698228d7e5d5b00563221.png",
@@ -5314,17 +5314,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 6.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 9.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -5336,7 +5336,7 @@ const waccaSongs = [
     artist: "崎山つばさ",
     dateAdded: 20200903,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 142,
     imageName:
       "f7ddcd3cb9dfac8704125b8a5fc0edc22ad9bfed586e69d72c6dfdee01eb2bdd.png",
@@ -5345,17 +5345,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -5367,7 +5367,7 @@ const waccaSongs = [
     artist: "超魂團（ウルトラソウルズ）",
     dateAdded: 20200903,
     dateRemoved: 0,
-    gameVersion: 2,
+    gameVersion: 150,
     bpm: 186,
     imageName:
       "c9088599c47536dbdb993f75905bb13b61b6fea89b0942652d82b0f27d14f48e.png",
@@ -5376,17 +5376,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 8,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 2,
+        gameVersion: 150,
         charter: "Marvelous",
       },
     ],
@@ -5398,7 +5398,7 @@ const waccaSongs = [
     artist: "T.M.Revolution",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 138,
     imageName:
       "53e8ca5d8255e6a1637af3dd05b36eb9a615e7d99621c73b5c31e2055ba5291e.png",
@@ -5407,17 +5407,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5429,7 +5429,7 @@ const waccaSongs = [
     artist: "KANA-BOON",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 175,
     imageName:
       "e15c6137e3f464ebed319b104125651c518aabcf4be34676b8a52cf7312fc9a9.png",
@@ -5438,17 +5438,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.1,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5460,7 +5460,7 @@ const waccaSongs = [
     artist: "aran & Kobaryo",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 175,
     imageName:
       "794fed8f770284c926e522bb8732896384f237e1b2a47360b5648a99600d7dfc.png",
@@ -5469,17 +5469,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5491,7 +5491,7 @@ const waccaSongs = [
     artist: "日向電工",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 172,
     imageName:
       "989244a625a54e5b5ff0bbf97d66915a79b32e7491b496395b68eeddd475bb81.png",
@@ -5500,17 +5500,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5522,7 +5522,7 @@ const waccaSongs = [
     artist: "NOMA w/ Apo11o program ft. Yuyoyuppe",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 160,
     imageName:
       "8ac7be89fedd48d5dc0dd5d4bdd6a20a9174045e247ec46160f46d1112b43f78.png",
@@ -5531,17 +5531,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5553,7 +5553,7 @@ const waccaSongs = [
     artist: "ＳＰＹＡＩＲ",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 240,
     imageName:
       "02347653dfc0c948a6b0b9e8182325d68e0dcec3cdb41a63e4d2781bd2ef2c6a.png",
@@ -5562,17 +5562,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 9.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5584,7 +5584,7 @@ const waccaSongs = [
     artist: "ずっと真夜中でいいのに。",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 130,
     imageName:
       "d6136b3d8116a0fde5f012a3d8421aeee0cd9ae3085fb7ce09189309a4e14467.png",
@@ -5593,17 +5593,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 6.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5616,7 +5616,7 @@ const waccaSongs = [
       "ガヴリール(CV:富田美憂)、ヴィーネ(CV:大西沙織)、サターニャ(CV:大空直美)、ラフィエル(CV:花澤香菜)",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 168,
     imageName:
       "ed73a7d69bc7b9441660f4a5fdff265378ae9751bcb20cff82ea1d7ca2845ea0.png",
@@ -5625,17 +5625,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 6.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5647,7 +5647,7 @@ const waccaSongs = [
     artist: "鈴木このみ",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 147,
     imageName:
       "f3a7e749202316ea4d63032482677283e1c6cb6f6c308a10ee2290581ff17927.png",
@@ -5656,17 +5656,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5678,7 +5678,7 @@ const waccaSongs = [
     artist: "キノシタ(kinoshita) feat.音街ウナ・鏡音リン",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 210,
     imageName:
       "06498d7c7dbc103652a89668002e6ed4f25e31ea704905d322f11d97c5432156.png",
@@ -5687,17 +5687,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5709,7 +5709,7 @@ const waccaSongs = [
     artist: "八王子P × Giga",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 105,
     imageName:
       "9ea90b46d6b17d3adbdaafea55e252132de7211f16ab8ce6f1512e96e3051e97.png",
@@ -5718,17 +5718,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.1,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5740,7 +5740,7 @@ const waccaSongs = [
     artist: "みきとP",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 130,
     imageName:
       "858c6f44463537a1c7a8e7e60df50c42b7ca5af418d550402315daafee9ded21.png",
@@ -5749,17 +5749,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5771,7 +5771,7 @@ const waccaSongs = [
     artist: "魂音泉",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 140,
     imageName:
       "6a3624e75e2612421cf87de3fc7ae7058f660c56d6f0002a9df7fa79d307c43a.png",
@@ -5780,17 +5780,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5802,7 +5802,7 @@ const waccaSongs = [
     artist: "岸田教団&THE明星ロケッツ",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 163,
     imageName:
       "46bb96103ee195362abe16a57857c4dd6cebd543271f421b94085814f8ab503a.png",
@@ -5811,17 +5811,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5833,7 +5833,7 @@ const waccaSongs = [
     artist: "LeaF",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 200,
     imageName:
       "bcd1dd82845b886e2ee6e86bd202e3f6847449cb844fb2c82d182424491b0c6c.png",
@@ -5842,17 +5842,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5864,7 +5864,7 @@ const waccaSongs = [
     artist: "Yunomi",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 128,
     imageName:
       "91f711573de4f5655f2e31c977ee8f732b8289694f18f903db8c0c3dbe0cf23a.png",
@@ -5873,17 +5873,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5895,7 +5895,7 @@ const waccaSongs = [
     artist: "t+pazolite & Massive New Krew feat. リリィ(CV:青木志貴)",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 155,
     imageName:
       "8b8fb8b70e6ba196be49878e880b4a4d7dacb53f39b1fe0ef0f6de4fd0c75ff7.png",
@@ -5904,22 +5904,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5931,7 +5931,7 @@ const waccaSongs = [
     artist: "RiraN",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 150,
     imageName:
       "1113fa97a84c5bc8970ceb90157bcd7214e3355d904ba64eeee7634ad6f449bd.png",
@@ -5940,17 +5940,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5962,7 +5962,7 @@ const waccaSongs = [
     artist: "かめりあ",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 213,
     imageName:
       "3a998ed730b9b9a59a725b9481a6acb24342fbb0a5a98c1fb15f8aafb00dc048.png",
@@ -5971,17 +5971,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 9.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -5993,7 +5993,7 @@ const waccaSongs = [
     artist: "Kobaryo feat. HiTNEX-X",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 152,
     imageName:
       "d52af8dc27ecad5903bbb67ded3166242f07dd9bbd96de6fb453977b85e67a47.png",
@@ -6002,17 +6002,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6024,7 +6024,7 @@ const waccaSongs = [
     artist: "t+pazolite feat. ななひら",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 158,
     imageName:
       "f4852b3973216a9628660c9b5f64fe18876d5742cc9cfeb9b7611d4a768d8ae8.png",
@@ -6033,17 +6033,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6055,7 +6055,7 @@ const waccaSongs = [
     artist: "DJ Myosuke",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 250,
     imageName:
       "cd3fb085a7706d3e8b5490b3389b800713d8e7b194f90ac5130060af2d5827e8.png",
@@ -6064,17 +6064,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 14.1,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6086,7 +6086,7 @@ const waccaSongs = [
     artist: "REDALiCE",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 170,
     imageName:
       "0e7b4fc6eec3df7165cc523c9af277997a04f1caaf87a4bfd2fb39dac4d1c0c2.png",
@@ -6095,17 +6095,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6117,7 +6117,7 @@ const waccaSongs = [
     artist: "hololive IDOL PROJECT",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 182,
     imageName:
       "89ddd8297fb0502968980503c0995ad55afab90a8f585c9d50e1fbd0d171c723.png",
@@ -6126,17 +6126,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6148,7 +6148,7 @@ const waccaSongs = [
     artist: "Run Girls, Run！",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 178,
     imageName:
       "dd89e5046e637c9e6ed1964fc69ac481f31ffc114631c8b29b6e93ca5e92e7c8.png",
@@ -6157,17 +6157,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6179,7 +6179,7 @@ const waccaSongs = [
     artist: "i☆Ris",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 172,
     imageName:
       "8e562535ed7e30fa809a55654118f75f5c1ad05f62c59998a238f754ef46dff1.png",
@@ -6188,17 +6188,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6210,7 +6210,7 @@ const waccaSongs = [
     artist: "彩瀬なる（CV.加藤英美里）",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 140,
     imageName:
       "fbcd7ab3cb5e3473c72ef2143ec5a97f439e9eea2c34f339c22e467a0c49fa41.png",
@@ -6219,17 +6219,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10.1,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6241,7 +6241,7 @@ const waccaSongs = [
     artist: "i☆Ris",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 172,
     imageName:
       "c8092ef108427de9e12e6e1dcf8c602fd7fe9dc99ebc7292665c378edfce0743.png",
@@ -6250,17 +6250,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 5.1,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 9.4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6272,7 +6272,7 @@ const waccaSongs = [
     artist: "Run Girls, Run！",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 168,
     imageName:
       "6fc34930a3a73510bd2e3fa2d342845e89072b95ca1e291a0d476cfb77780048.png",
@@ -6281,17 +6281,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10.2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6303,7 +6303,7 @@ const waccaSongs = [
     artist: "ミュージカル『テニスの王子様』3rdシーズン",
     dateAdded: 20200917,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 150,
     imageName:
       "97d1c8d812f3e1466122f9e3fc97b2b5b0ab79369ce587e6275f6193a33c65b2.png",
@@ -6312,17 +6312,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 6.1,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 9.3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6334,7 +6334,7 @@ const waccaSongs = [
     artist: "Orangestar feat.IA",
     dateAdded: 20201001,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 185,
     imageName:
       "222d40b6450662187cad4d455c7b035fb9bc7b6eebc2131a4395d41cd2b31e35.png",
@@ -6343,17 +6343,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6365,7 +6365,7 @@ const waccaSongs = [
     artist: "GigaReol",
     dateAdded: 20201001,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 140,
     imageName:
       "b504ed0a449ad2b8395217c5cbebcfd57675f55fd20226a822f93d1265469676.png",
@@ -6374,17 +6374,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6396,7 +6396,7 @@ const waccaSongs = [
     artist: "れるりり",
     dateAdded: 20201001,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 155,
     imageName:
       "a0c5a20e1be2f2ad467ebe195e307f3a1fcd260f024796964a85104a0673fdb1.png",
@@ -6405,17 +6405,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 9.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6427,7 +6427,7 @@ const waccaSongs = [
     artist: "Getty vs. DJ DiA",
     dateAdded: 20201008,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 190,
     imageName:
       "9c01fe7a70edaa36678417c6a19b011dcd5fd11a0232aa4eea96ab7623bfe752.png",
@@ -6436,17 +6436,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 9.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6458,7 +6458,7 @@ const waccaSongs = [
     artist: "BlackY",
     dateAdded: 20201008,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 186,
     imageName:
       "7629d2e989f875f3990d1ec6b2602a45458d4140a59f17ea8e6508a0be780468.png",
@@ -6467,17 +6467,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6489,7 +6489,7 @@ const waccaSongs = [
     artist: "P*Light",
     dateAdded: 20201008,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 175,
     imageName:
       "7939f3e28b7272e4bc67d346294e75ab191b2788720b0558e605e921f97db4cd.png",
@@ -6498,17 +6498,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 9.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6520,7 +6520,7 @@ const waccaSongs = [
     artist: "sumijun(Halozy) feat. ななひら(Confetto)",
     dateAdded: 20201015,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 199,
     imageName:
       "8955aaa4fade748abae735d95235b38c8f0c800354e10f696c1e40e2197c5994.png",
@@ -6529,17 +6529,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6551,7 +6551,7 @@ const waccaSongs = [
     artist: "REDALiCE & aran",
     dateAdded: 20201015,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 190,
     imageName:
       "69cfb4e68a14b57554c6a3c97d50455770af9524a16dc0f18a8ac316a8de9d2e.png",
@@ -6560,17 +6560,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 9.2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6582,7 +6582,7 @@ const waccaSongs = [
     artist: "ビートまりお（COOL&CREATE）",
     dateAdded: 20201015,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 184,
     imageName:
       "ad50af4ca81e7142543766932d62f2589e811c86285b1b407e24bf1c66aa92fb.png",
@@ -6591,17 +6591,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6613,7 +6613,7 @@ const waccaSongs = [
     artist: "井口裕香",
     dateAdded: 20201022,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 160,
     imageName:
       "1f9f81a88ca248db244efe9a912376c0d5ebe98dbba9ea111a4c6a3cfb6f8754.png",
@@ -6622,17 +6622,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 6.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 9.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6644,7 +6644,7 @@ const waccaSongs = [
     artist: "井口裕香",
     dateAdded: 20201022,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 170,
     imageName:
       "70c5b7ede17cf5e4bd1c13e78559bd890df6c3cd3f5d3c3bc195a2f5cdf16a2c.png",
@@ -6653,17 +6653,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10.4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6675,7 +6675,7 @@ const waccaSongs = [
     artist: "アイズ・ヴァレンシュタイン（cv.大西沙織）",
     dateAdded: 20201022,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 162,
     imageName:
       "4bf0d16066ef637540863e57a7dc41f9e14a549f34791bf18ccda0820c77c0e0.png",
@@ -6684,17 +6684,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6706,7 +6706,7 @@ const waccaSongs = [
     artist: "紗倉ひびき(CV：ファイルーズあい)＆街雄鳴造(CV：石川界人)",
     dateAdded: 20201105,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 132,
     imageName:
       "03115b8281cb176ef67f85fd0a5a8b03131df2b9680fd1817a7541844610b973.png",
@@ -6715,17 +6715,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6737,7 +6737,7 @@ const waccaSongs = [
     artist: "街雄鳴造（ＣＶ：石川界人）",
     dateAdded: 20201105,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 132,
     imageName:
       "e2beb7ea5dacbe53d513d87abda5fb9722b9dd2ec8ee25edf9fc18bf8b3a2e45.png",
@@ -6746,17 +6746,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 6.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6768,7 +6768,7 @@ const waccaSongs = [
     artist: "REDALiCE feat. 兎田ぺこら&さくらみこ",
     dateAdded: 20201119,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 180,
     imageName:
       "0835e1128ce13a0f58ba812456e635744f85a6348a5f82121e30edcb85c8fe28.png",
@@ -6777,22 +6777,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6804,7 +6804,7 @@ const waccaSongs = [
     artist: "白上フブキ",
     dateAdded: 20201119,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 170,
     imageName:
       "ee6bfd298768df39b5085ffb1fe6eaeba2b2cfe20ff51a685b8718d849f13351.png",
@@ -6813,17 +6813,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6835,7 +6835,7 @@ const waccaSongs = [
     artist: "hololive IDOL PROJECT",
     dateAdded: 20201119,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 180,
     imageName:
       "7c5c07b47c32341aa6056aa91a89bb1a986e36c27886b8bd18ab493d0f4b25c6.png",
@@ -6844,17 +6844,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6866,7 +6866,7 @@ const waccaSongs = [
     artist: "星街すいせい",
     dateAdded: 20201119,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 132,
     imageName:
       "ce903004e8df957b4009b747f3d9e72455906d6ffe312f06ebf6716cf089293b.png",
@@ -6875,17 +6875,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6897,7 +6897,7 @@ const waccaSongs = [
     artist: "DJ Genki",
     dateAdded: 20201203,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 230,
     imageName:
       "c1e5c576e1e2a055ceb798f2201a9d7cf030ab03ee88d987cdf404ef556969c2.png",
@@ -6906,17 +6906,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6928,7 +6928,7 @@ const waccaSongs = [
     artist: "源屋",
     dateAdded: 20201203,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 172,
     imageName:
       "143c891879bd709a508d00641f1986396c6829b34344c71face47284520dec35.png",
@@ -6937,17 +6937,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6959,7 +6959,7 @@ const waccaSongs = [
     artist: "Srav3R",
     dateAdded: 20201203,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 175,
     imageName:
       "9d0c1726e2b1a8877570a044f72a5965635b98830a7ef1949bfed751ace7ab6c.png",
@@ -6968,17 +6968,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -6990,7 +6990,7 @@ const waccaSongs = [
     artist: "aran & lapix",
     dateAdded: 20201203,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 165,
     imageName:
       "13bca3858de2618db3bd3528f35f2e5eb2934bf91b50230d13aa1441c8385d2e.png",
@@ -6999,17 +6999,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7021,7 +7021,7 @@ const waccaSongs = [
     artist: "t+pazolite 「グルーヴコースター」より",
     dateAdded: 20201216,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 285,
     imageName:
       "c70a2a7ec51b5e2eb5a6d0cf4726120c869680e6fbcc91cd45d83f8dc2f5d335.png",
@@ -7030,17 +7030,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7052,7 +7052,7 @@ const waccaSongs = [
     artist: "E.G.G. 「グルーヴコースター」より",
     dateAdded: 20201216,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 266,
     imageName:
       "d2c68f67d11af57437e67b6dcb353636965cdc57fff58e707632691d15af3ad0.png",
@@ -7061,17 +7061,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7083,7 +7083,7 @@ const waccaSongs = [
     artist: "ビートまりお＋あまね 「グルーヴコースター」より",
     dateAdded: 20201216,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 190,
     imageName:
       "3a050e44b53b35cf78095f2d7a68824c081436487eef0100756910af78681358.png",
@@ -7092,17 +7092,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7114,7 +7114,7 @@ const waccaSongs = [
     artist: "DJ Noriken vs MASAKI",
     dateAdded: 20201216,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 200,
     imageName:
       "de6d74e8ca7e824743fb0ad53379ba8f702c063a79c68671ee0d5fdcab134da6.png",
@@ -7123,17 +7123,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7145,7 +7145,7 @@ const waccaSongs = [
     artist: "P*Light",
     dateAdded: 20201224,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 165,
     imageName:
       "2b6e9d555d227894425c78f9bec42d8bb2b5bca23da6637979d7bebd8512dd10.png",
@@ -7154,17 +7154,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7176,7 +7176,7 @@ const waccaSongs = [
     artist: "野猿",
     dateAdded: 20201224,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 147,
     imageName:
       "2dc626c7725737a966a8856ce52f19a8056e51cc0eabc65dc0b4c8a35eba2471.png",
@@ -7185,17 +7185,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7207,7 +7207,7 @@ const waccaSongs = [
     artist: "group_inou",
     dateAdded: 20201224,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 150,
     imageName:
       "c2d6f1473fe81c49bb0344a9b5f116b57c85b96d5b88dc5713d6dcf46d97ec2e.png",
@@ -7216,17 +7216,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 9.1,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7238,7 +7238,7 @@ const waccaSongs = [
     artist: "aran & Kobaryo",
     dateAdded: 20201224,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 150,
     imageName:
       "995d676035ed10af759b03775d85fc934a846350fe0a41919d0bce0906fbcb55.png",
@@ -7247,17 +7247,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7269,7 +7269,7 @@ const waccaSongs = [
     artist: "ミュージカル『テニスの王子様』3rdシーズン",
     dateAdded: 20201224,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 158,
     imageName:
       "271875d9c6ac1a25c6d2733fdcdf5d800f384448cf8f6fe834a8d4bd25a14302.png",
@@ -7278,17 +7278,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 6.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7300,7 +7300,7 @@ const waccaSongs = [
     artist: "オワタP",
     dateAdded: 20210107,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 120,
     imageName:
       "332b273a486da9aec2c9c9e63c59ca9417f9738a8c151ed8d8e00e5b96a13eaf.png",
@@ -7309,17 +7309,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7331,7 +7331,7 @@ const waccaSongs = [
     artist: "supercell",
     dateAdded: 20210107,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 165,
     imageName:
       "ec515a700fb69c66c892520a760504070563bc7b5e01597720eecfdfdb17e833.png",
@@ -7340,17 +7340,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7362,7 +7362,7 @@ const waccaSongs = [
     artist: "sasakure. UK",
     dateAdded: 20210107,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 122,
     imageName:
       "88e91a709946a088b48f015665bfdfdd8961269af770808e186149d73dd04875.png",
@@ -7371,17 +7371,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 9.1,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7393,7 +7393,7 @@ const waccaSongs = [
     artist: "ろひ",
     dateAdded: 20210107,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 200,
     imageName:
       "9141ce8fa22a6e80f57086ddeb3e5a97332b6f26fef443d84997dfb6216f6b3b.png",
@@ -7402,17 +7402,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7424,7 +7424,7 @@ const waccaSongs = [
     artist: "Neko Hacker",
     dateAdded: 20210204,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 160,
     imageName:
       "3526054d8582a865c74e6c5b2a249cefd09ab044ebcbdec9857724a8ecdf3b4a.png",
@@ -7433,17 +7433,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7455,7 +7455,7 @@ const waccaSongs = [
     artist: "KOTONOHOUSE",
     dateAdded: 20210204,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 140,
     imageName:
       "fd3332dbd6d7eee8f45f5453f1cca906449611372febe04c17299570f9990f18.png",
@@ -7464,17 +7464,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7486,7 +7486,7 @@ const waccaSongs = [
     artist: "Pa's Lam System",
     dateAdded: 20210204,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 170,
     imageName:
       "b0d3f00fd1287b3497399f454dfe583598460fa69f4150781e2e56ec15d85586.png",
@@ -7495,17 +7495,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7517,7 +7517,7 @@ const waccaSongs = [
     artist: "YUC'e",
     dateAdded: 20210204,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 180,
     imageName:
       "9adcfa281f68c1f94accb5dd889f0a458e2fb44638a7ee44301122e5ad9b1c31.png",
@@ -7526,17 +7526,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 9.1,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7548,7 +7548,7 @@ const waccaSongs = [
     artist: "かねこちはる",
     dateAdded: 20210218,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 140,
     imageName:
       "47b67be668f9136e73a15cf5f7c1345bf4a6726fc04cc7422fda13ed83a46e63.png",
@@ -7557,17 +7557,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10.6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7579,7 +7579,7 @@ const waccaSongs = [
     artist: "Zekk",
     dateAdded: 20210218,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 180,
     imageName:
       "b2fcbaf38886d691751fd8dcc893c521af95b35b72f16c972c4a799eb1289aca.png",
@@ -7588,17 +7588,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 8.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7610,7 +7610,7 @@ const waccaSongs = [
     artist: "USAO",
     dateAdded: 20210218,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 155,
     imageName:
       "ac261381f3399380cad798e2607cf5e8cdd9bee46cd496632476a0f4223d5f27.png",
@@ -7619,17 +7619,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 9.5,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.1,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7641,7 +7641,7 @@ const waccaSongs = [
     artist: "Laur",
     dateAdded: 20210218,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 210,
     imageName:
       "6d8f5431a0581e7615aebece00f75154be37b5609e4f15e0442eee8da1e37597.png",
@@ -7650,17 +7650,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7672,7 +7672,7 @@ const waccaSongs = [
     artist: "Massive New Krew",
     dateAdded: 20210218,
     dateRemoved: 0,
-    gameVersion: 3,
+    gameVersion: 200,
     bpm: 160,
     imageName:
       "9a088e49971fe41c9b152e59bfc13a5346430ec6583b6b15444e1229a77170b5.png",
@@ -7681,17 +7681,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 7,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
       {
         difficulty: 14,
-        gameVersion: 3,
+        gameVersion: 200,
         charter: "Marvelous",
       },
     ],
@@ -7703,7 +7703,7 @@ const waccaSongs = [
     artist: "kemu",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 186,
     imageName:
       "e6ccc26a6452dcad96b89d8261b900611f737b9ee30af6019d437f938d9cdb68.png",
@@ -7712,17 +7712,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -7734,7 +7734,7 @@ const waccaSongs = [
     artist: "まふまふ",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 192,
     imageName:
       "c9c56adfec65017958d8f7bcb940a3f2dd338895aef5af950af1209555a0413a.png",
@@ -7743,17 +7743,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 9.1,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.2,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -7765,7 +7765,7 @@ const waccaSongs = [
     artist: "ARM(IOSYS)",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 170,
     imageName:
       "5bba02cf5f7431932f777c257b8a27ae2384c792d2ae4feb746374943b36737b.png",
@@ -7774,17 +7774,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 11.5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -7796,7 +7796,7 @@ const waccaSongs = [
     artist: "fripSide",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 144,
     imageName:
       "712aec6ab2cbf4940fc1781b69f6b5b320d9f2e34c607bed18ee345c326b4f30.png",
@@ -7805,17 +7805,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 6,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 10.1,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -7827,7 +7827,7 @@ const waccaSongs = [
     artist: "ユアミトス ｢Lanota｣より",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 188,
     imageName:
       "c8fdcade2a5d82a94cb88915ea0b4d6af5509666da7eb2909aad7b20aa54cd5f.png",
@@ -7836,17 +7836,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.6,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -7858,7 +7858,7 @@ const waccaSongs = [
     artist: "アリスシャッハと魔法の楽団 ｢Lanota｣より",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 220,
     imageName:
       "17356f1b8878e053bb502d6f04355788f654d7fa4c3a5eb3e78208c4340cf397.png",
@@ -7867,17 +7867,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 7.6,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -7889,7 +7889,7 @@ const waccaSongs = [
     artist: "Kamome sano ｢Lanota｣より",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 180,
     imageName:
       "13e7f0da79dad006646cae162c00c4a8fe0c39bf87e3a12b5055bacccc9fcc69.png",
@@ -7898,17 +7898,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 9.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -7920,7 +7920,7 @@ const waccaSongs = [
     artist: "t+pazolite ｢Lanota｣より",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 163,
     imageName:
       "08e5154f757cac9d09490162b95607d5a0bb6b1b94c648375e05e1c121c723de.png",
@@ -7929,17 +7929,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 10,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -7951,7 +7951,7 @@ const waccaSongs = [
     artist: "Maozon ｢Lanota｣より",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 180,
     imageName:
       "5e84dd24b72c7eece7e8f565afda72a4bf03ed78dfaa574344d00e9155bcc267.png",
@@ -7960,17 +7960,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 10.2,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.6,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -7982,7 +7982,7 @@ const waccaSongs = [
     artist: "宝鐘マリン with ホロイズムファンタジー",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 195,
     imageName:
       "af671f750e25e40657cdbebf992ae0e1069176022d2f2fe97c84178eced14fd3.png",
@@ -7991,17 +7991,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8013,7 +8013,7 @@ const waccaSongs = [
     artist: "鹿乃と宇崎ちゃん",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 150,
     imageName:
       "bc55f70466a0f1e98e5a6842d89278513158c1a0b55a3ad15066e13430cb0d85.png",
@@ -8022,17 +8022,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 11.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8044,7 +8044,7 @@ const waccaSongs = [
     artist: "綾瀬理恵",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 158,
     imageName:
       "43481f6869666d2e6929670f591379a3b2c873bb46d4fe2eff79aedf15f9e375.png",
@@ -8053,17 +8053,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8075,7 +8075,7 @@ const waccaSongs = [
     artist: "A-One",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 165,
     imageName:
       "f3c5096fed9421ad1e5155335ca411809ef94c00000bc22357a7bc056c7ab058.png",
@@ -8084,17 +8084,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.1,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8106,7 +8106,7 @@ const waccaSongs = [
     artist: "EmoCosine",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 150,
     imageName:
       "4a09f7111ced87cc860c027bca2c1539cbb41955652b21caececc8b324ced80e.png",
@@ -8115,17 +8115,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.1,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8137,7 +8137,7 @@ const waccaSongs = [
     artist: "DJ Myosuke",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 220,
     imageName:
       "d0b6718662cc40750f5a29733d81f31c300258c87f6b7823d9badc589b0604a9.png",
@@ -8146,17 +8146,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 10,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.6,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8168,7 +8168,7 @@ const waccaSongs = [
     artist: "Laur",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 175,
     imageName:
       "e19d3a40c7c7510e8776e73419f933951de0212459d21d8afa1dd820d809f58f.png",
@@ -8177,22 +8177,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 9.1,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
 	  {
         difficulty: 14.1,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "やくさんす？ VS レイエズ",
       },
     ],
@@ -8204,7 +8204,7 @@ const waccaSongs = [
     artist: "sasakure.UK",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 250,
     imageName:
       "6bb9aa9501f623e5314f9360232de790b7884e07fba4268a813ededf99ee8dfb.png",
@@ -8213,17 +8213,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8235,7 +8235,7 @@ const waccaSongs = [
     artist: "Feryquitous",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 191,
     imageName:
       "c6aef61fa2501481c1bc1f85761e74e67d40ceea59b1514bd7b87d7075cba822.png",
@@ -8244,17 +8244,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 9.6,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8266,7 +8266,7 @@ const waccaSongs = [
     artist: "REDALiCE",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 180,
     imageName:
       "bc3200a18e39d76224075729cdbb012c08850e8236fdc583180e3840bd05c39d.png",
@@ -8275,17 +8275,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 9.5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8297,7 +8297,7 @@ const waccaSongs = [
     artist: "Srav3R vs Getty",
     dateAdded: 20210311,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 200,
     imageName:
       "5d55dfeb21e6aa589e4b3e31cb8e5788f12e276d4266a241e8b96224d25ef935.png",
@@ -8306,17 +8306,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 10.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8328,7 +8328,7 @@ const waccaSongs = [
     artist: "すりぃ feat.鏡音レン",
     dateAdded: 20210325,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 182,
     imageName:
       "7d72de57b85291fd82c4f448c3bc6c91201409ef7b67c822cae2c9c65093374c.png",
@@ -8337,17 +8337,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 11.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8359,7 +8359,7 @@ const waccaSongs = [
     artist: "みきとP",
     dateAdded: 20210325,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 150,
     imageName:
       "9afa7c3b731465edad8f94c6f6e72760dedfa7c4c87d3c98c97b204ed74cabac.png",
@@ -8368,17 +8368,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.2,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 11.6,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8390,7 +8390,7 @@ const waccaSongs = [
     artist: "ぬゆり",
     dateAdded: 20210325,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 135,
     imageName:
       "cacbb5997115f880fe1ac358f0308196ee99e6bede85ba95c6f9a3a779e15248.png",
@@ -8399,17 +8399,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 7.3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8421,7 +8421,7 @@ const waccaSongs = [
     artist: "ユリイ・カノン feat.GUMI",
     dateAdded: 20210325,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 145,
     imageName:
       "5175dd340258412f0e51b70bcc544422a6b6c2b57448240cd3c66e75019fa084.png",
@@ -8430,17 +8430,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 7.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.1,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8452,7 +8452,7 @@ const waccaSongs = [
     artist: "ARM＋夕野ヨシミ (IOSYS) feat. miko",
     dateAdded: 20210408,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 200,
     imageName:
       "13a562a1ccce4939dee4cec168591ecc8d5835dccb6c33f9e1c248624d7c076a.png",
@@ -8461,17 +8461,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 9.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.2,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8483,7 +8483,7 @@ const waccaSongs = [
     artist: "Halozy",
     dateAdded: 20210408,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 180,
     imageName:
       "1776844ca83165b5ae1ce78911bddedbed4d0c0653d6713f0dd3664b00d758d3.png",
@@ -8492,17 +8492,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 9.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.2,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8514,7 +8514,7 @@ const waccaSongs = [
     artist: "モリモリあつし",
     dateAdded: 20210415,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 202,
     imageName:
       "feece5b0bedb3f7e37190b6f16247efff8356523e5b2571e0da4516c2fd6cefa.png",
@@ -8523,17 +8523,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.6,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8545,7 +8545,7 @@ const waccaSongs = [
     artist: "削除 feat Nikki Simmons",
     dateAdded: 20210415,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 90,
     imageName:
       "aba8290ff05294e2b72607b3b9682222820bcc6c68a7d73c01d0217bdab9823a.png",
@@ -8554,17 +8554,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8576,7 +8576,7 @@ const waccaSongs = [
     artist: "LeaF",
     dateAdded: 20210415,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 100,
     imageName:
       "44ceb2fa1dca869c148645ba1611f5b930f4c8b1bafa76c0b578b09f2b8183fb.png",
@@ -8585,17 +8585,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.2,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8607,7 +8607,7 @@ const waccaSongs = [
     artist: "DJ Genki & P*Light",
     dateAdded: 20210429,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 180,
     imageName:
       "f628a540634458175a9b665e528cb6225fe49f5821d826fa8687ae3ae6454ff9.png",
@@ -8616,17 +8616,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8638,7 +8638,7 @@ const waccaSongs = [
     artist: "DJ Myosuke & aran",
     dateAdded: 20210429,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 180,
     imageName:
       "dd76c14414624f5311289c8f3e0292919b149b79c6ac4a989b0648a8eb225ec2.png",
@@ -8647,17 +8647,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 9.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8669,7 +8669,7 @@ const waccaSongs = [
     artist: "Lite Show Magic",
     dateAdded: 20210429,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 220,
     imageName:
       "c7836946b9bee08a0104208a67bc10de3b823876cd93b4409417e9f89401c0f1.png",
@@ -8678,17 +8678,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8700,7 +8700,7 @@ const waccaSongs = [
     artist: "森羅万象",
     dateAdded: 20210513,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 174,
     imageName:
       "d39003477e2204615badd168c99b0b8a3df210d23c7b143a88c7cde04c16456b.png",
@@ -8709,17 +8709,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.6,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8731,7 +8731,7 @@ const waccaSongs = [
     artist: "SYNC.ART'S feat. 美里",
     dateAdded: 20210513,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 155,
     imageName:
       "35d576cbc1252915f65e360b5cb08692d6e60c90141c1637564cee70d2d90c73.png",
@@ -8740,17 +8740,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 11.3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8762,7 +8762,7 @@ const waccaSongs = [
     artist: "Masayoshi Minoshima(Alstroemeria Records)",
     dateAdded: 20210513,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 180,
     imageName:
       "2014cf84e109a7add29540731e9fac58c94e7caed5370ec3b86fc90e5c094137.png",
@@ -8771,17 +8771,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 9.2,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8793,7 +8793,7 @@ const waccaSongs = [
     artist: "koutaq",
     dateAdded: 20210513,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 135,
     imageName:
       "792c3e70cc49b0860b655588b11f664d759ed3056729a04754c2d27fa4aa0b97.png",
@@ -8802,17 +8802,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 9.1,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8824,7 +8824,7 @@ const waccaSongs = [
     artist: "Kobaryo",
     dateAdded: 20210513,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 495,
     imageName:
       "3e05b39464c2af38cc9632c435e48234a199529036a68939561f8537dac36f97.png",
@@ -8833,17 +8833,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8855,7 +8855,7 @@ const waccaSongs = [
     artist: "Happy Around!＆Peaky P-key 「D4DJ Groovy Mix」より",
     dateAdded: 20210527,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 157,
     imageName:
       "7d5866da27e421e0a66da110f030e336b2cee82cb6be68d9b8654ed058f6cd41.png",
@@ -8864,22 +8864,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8891,7 +8891,7 @@ const waccaSongs = [
     artist: "Happy Around! 「D4DJ Groovy Mix」より",
     dateAdded: 20210527,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 179,
     imageName:
       "6fdb6f8d1adfa6937be3a6e40292c5a94d49ef9963f525cebf232ce158879f2d.png",
@@ -8900,17 +8900,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 11.4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8922,7 +8922,7 @@ const waccaSongs = [
     artist: "Peaky P-key 「D4DJ Groovy Mix」より",
     dateAdded: 20210527,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 139,
     imageName:
       "9f18a4d96da7dd20c550312d32397d80692fcd352a318daa2b6890b973212250.png",
@@ -8931,17 +8931,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 7.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8953,7 +8953,7 @@ const waccaSongs = [
     artist: "Photon Maiden 「D4DJ Groovy Mix」より",
     dateAdded: 20210527,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 128,
     imageName:
       "a19f5c0e7f8f2551b898639335ff4f52d6b3afceebf7cc2ab4a363c71cc53aa6.png",
@@ -8962,17 +8962,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 11.5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -8984,7 +8984,7 @@ const waccaSongs = [
     artist: "Happy Around! feat. KYOKO & SAKI 「D4DJ Groovy Mix」より",
     dateAdded: 20210527,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 220,
     imageName:
       "0c632d28155d98f7076eeb9b2c5f5ab1fd75b4cf5f5eac0ef9530d4df1f0857b.png",
@@ -8993,17 +8993,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 10.1,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9015,7 +9015,7 @@ const waccaSongs = [
     artist: "t+pazolite",
     dateAdded: 20210610,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 220,
     imageName:
       "6b3b6039403ace643c2cde7f86206178d2e083e8c41019b9ae42dd94157d074a.png",
@@ -9024,17 +9024,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 10.3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.1,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9046,7 +9046,7 @@ const waccaSongs = [
     artist: "かめりあ vs DJ Genki",
     dateAdded: 20210610,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 170,
     imageName:
       "dc59c35a84fdce2488c4749675261d5769a889dd67cde2fe3265b38138e7a9bf.png",
@@ -9055,17 +9055,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9077,7 +9077,7 @@ const waccaSongs = [
     artist: "Getty",
     dateAdded: 20210610,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 160,
     imageName:
       "8603ec91379055726538a015f3591da57889bd0b08c3b9d2ee9a84031136bd96.png",
@@ -9086,17 +9086,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 9.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9108,7 +9108,7 @@ const waccaSongs = [
     artist: "Massive New Krew",
     dateAdded: 20210610,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 155,
     imageName:
       "d43aba573228f252c2948893bcdef95792068a4dfbdac69b75f99df34ae1f1ca.png",
@@ -9117,17 +9117,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9139,7 +9139,7 @@ const waccaSongs = [
     artist: "YUC'e",
     dateAdded: 20210624,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 120,
     imageName:
       "285e014d10872bc428e1f3a0e5a7f9b9c4297a4068323277c70745bc4c1a86a7.png",
@@ -9148,17 +9148,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 6.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9170,7 +9170,7 @@ const waccaSongs = [
     artist: "HiTECH NINJA",
     dateAdded: 20210624,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 138,
     imageName:
       "6dfff158b6877b32755499f7d84ebf0da8bb3ea59b6d061bedcd7a7c54a8e814.png",
@@ -9179,17 +9179,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9201,7 +9201,7 @@ const waccaSongs = [
     artist: "Mameyudoufu",
     dateAdded: 20210624,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 185,
     imageName:
       "e182a0ba93a7c56a68c0f11f313fa0bc31c98ba4e95c9493c5e9de21ed697b9d.png",
@@ -9210,17 +9210,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9232,7 +9232,7 @@ const waccaSongs = [
     artist: "「アズールレーン」より",
     dateAdded: 20210701,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 170,
     imageName:
       "9aaa9d7dc2d5bb086a67a106962245a279cd4cbf261d7f1f58ce5ab1d1a6ab88.png",
@@ -9241,17 +9241,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 7.8,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9263,7 +9263,7 @@ const waccaSongs = [
     artist: "Polaris「アズールレーン」より",
     dateAdded: 20210701,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 188,
     imageName:
       "bd89a3f43fb76481adb6b2a21488a010ebc33c828b5bb54b5b0136e7c52f1b9f.png",
@@ -9272,17 +9272,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9294,7 +9294,7 @@ const waccaSongs = [
     artist: "サンディエゴ（CV:伊藤あすか）「アズールレーン」より",
     dateAdded: 20210701,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 178,
     imageName:
       "d9a2fc196cd9a4f69470a005de7c4f63bd08179749cdd5d90797e27c2459527e.png",
@@ -9303,17 +9303,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 8.4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9325,7 +9325,7 @@ const waccaSongs = [
     artist: "P*Light",
     dateAdded: 20210715,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 200,
     imageName:
       "58cbbaa8d29c7936af95bb27088c08a6f2156e83a42385f4b28539731ca16c35.png",
@@ -9334,17 +9334,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 9.2,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.1,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9356,7 +9356,7 @@ const waccaSongs = [
     artist: "Yooh",
     dateAdded: 20210715,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 135,
     imageName:
       "6b7dc7e3972e6a1fec1bf97a9c648a280132d28fb1163f36dd742a8d83bba849.png",
@@ -9365,17 +9365,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 10.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9387,7 +9387,7 @@ const waccaSongs = [
     artist: '漆黒の堕天使《Gram》†Versus† "聖刻"の熾天使《Gram》',
     dateAdded: 20210715,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 245,
     imageName:
       "3afce4c0b8feb273da8d498133d37a11e137c60b01e5723335bab07733980df9.png",
@@ -9396,22 +9396,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 14.1,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9423,7 +9423,7 @@ const waccaSongs = [
     artist: "t+pazolite VS 削除",
     dateAdded: 20210715,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 290,
     imageName:
       "ed772b255b7968e315d9bd3fc59626a8c37a47aaee7846a0fb00588bbbf1160b.png",
@@ -9432,22 +9432,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 10.3,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.6,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 14.1,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9459,7 +9459,7 @@ const waccaSongs = [
     artist: "Kobaryo",
     dateAdded: 20210715,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 400,
     imageName:
       "c7a60f32e24e6ac90796c46012c8c68c96ee47ae9034bf74cd1c9166ecc0020e.png",
@@ -9468,17 +9468,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 13.4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9490,7 +9490,7 @@ const waccaSongs = [
     artist: "ARuFa",
     dateAdded: 20210729,
     dateRemoved: 0,
-    gameVersion: 4,
+    gameVersion: 250,
     bpm: 140,
     imageName:
       "e76ae15b0244740abe8f6321f8ff476d617f651b5e0c57008a48a97eeacdf71a.png",
@@ -9499,17 +9499,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 7.9,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 4,
+        gameVersion: 250,
         charter: "Marvelous",
       },
     ],
@@ -9521,7 +9521,7 @@ const waccaSongs = [
     artist: "40mP",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 135,
     imageName:
       "1b5cebb191e7db0da7d3be2dc73a89382e385305fc1a078dab38e5c19861867e.png",
@@ -9530,17 +9530,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 7.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9552,7 +9552,7 @@ const waccaSongs = [
     artist: "ド葛本社",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 150,
     imageName:
       "6974da4b6c8db1a1d9d57100bac1476e033d5c12da8693c4644e9265538baae8.png",
@@ -9561,17 +9561,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9583,7 +9583,7 @@ const waccaSongs = [
     artist: "Kanaria",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 166,
     imageName:
       "68e1dd456b16e0720e1ec8aaf8f3029828f394755388c2262478c87a2560c5f0.png",
@@ -9592,17 +9592,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9614,7 +9614,7 @@ const waccaSongs = [
     artist: "かいりきベア",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 153,
     imageName:
       "7eab87c6dad838a1bb345933a23a6385f2db0d42d81aaf2f10472457a4d3c486.png",
@@ -9623,17 +9623,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9645,7 +9645,7 @@ const waccaSongs = [
     artist: "じん",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 185,
     imageName:
       "aaf5e2d403e985c47328d8a806f41ee42e3ecec80f8f040b301df42453d8c032.png",
@@ -9654,17 +9654,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 7.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9676,7 +9676,7 @@ const waccaSongs = [
     artist: "Noizenecio",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 180,
     imageName:
       "8d733ddfcce404ffce2757a54f3f444a40cb28a0f866c5d2572d6954e79634bc.png",
@@ -9685,17 +9685,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9707,7 +9707,7 @@ const waccaSongs = [
     artist: "t+pazolite",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 175,
     imageName:
       "27b8cadb830a6fad411a276216ce1be19f9b8f4d7856868d6696a6ce1226f838.png",
@@ -9716,17 +9716,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 7.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9738,7 +9738,7 @@ const waccaSongs = [
     artist: "USAO & DJ Genki feat. ルーン(CV:河瀬茉希)",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 200,
     imageName:
       "1b74151ef7a98c68f85579c219f8500f011523150fdd7e00b844845cef8bc934.png",
@@ -9747,22 +9747,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9774,7 +9774,7 @@ const waccaSongs = [
     artist: "EmoCosine",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 160,
     imageName:
       "a1fd5fceb401d835593700b8a354350e5f08c2422b9598b939bb6c66096c9332.png",
@@ -9783,17 +9783,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9805,7 +9805,7 @@ const waccaSongs = [
     artist: "Massive New Krew",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 205,
     imageName:
       "3954db3c156d9177e53548b6563f11f491021fc5f7ee9ede05bdf0a9384fc893.png",
@@ -9814,17 +9814,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9836,7 +9836,7 @@ const waccaSongs = [
     artist: "モリモリあつし",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 201,
     imageName:
       "beac9430988072ce57c2532da4e4d554355b255e231101a0d6d7811ec6321f5a.png",
@@ -9845,17 +9845,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9867,7 +9867,7 @@ const waccaSongs = [
     artist: "DJ Noriken",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 205,
     imageName:
       "b2220ad58ea1bbbc315d86a13662afeb020c442d6dddd2694f5804a0dd318c7e.png",
@@ -9876,17 +9876,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9898,7 +9898,7 @@ const waccaSongs = [
     artist: "Sampling Masters MEGA",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 200,
     imageName:
       "98871d98029612d929e5c08f9dc9fe575fb14d5ab86c2140b21ec76a576594d4.png",
@@ -9907,17 +9907,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9929,7 +9929,7 @@ const waccaSongs = [
     artist: "かめりあ(EDP)",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 181,
     imageName:
       "ea34dd9c2ba7cd3ecb0cd85e0277de7234bfb07ed77038434e25d38121777e8b.png",
@@ -9938,17 +9938,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9960,7 +9960,7 @@ const waccaSongs = [
     artist: "Feryquitous",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 191,
     imageName:
       "a36c9861ffe4d5a327b1e157b5055fd51f8a256cd7d76d41ddeba4b419c90fa2.png",
@@ -9969,17 +9969,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -9991,7 +9991,7 @@ const waccaSongs = [
     artist: "REDALiCE vs USAO",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 205,
     imageName:
       "641fd96700ee92cfa920972b92359aa00dfe4c70a6e2bf49791c4355d4e6bca7.png",
@@ -10000,17 +10000,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10022,7 +10022,7 @@ const waccaSongs = [
     artist: "Laur",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 200,
     imageName:
       "22cb6e0190eabc6f3e8e60e3af68f419e03927875777158ee06e512171be9d25.png",
@@ -10031,17 +10031,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10053,7 +10053,7 @@ const waccaSongs = [
     artist: "nitro (lowiro)",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 185,
     imageName:
       "057348477eb69e9fe507270e528fe8ab6ffaba100408ab33cc84963437d6f2e3.png",
@@ -10062,17 +10062,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10084,7 +10084,7 @@ const waccaSongs = [
     artist: "Ado",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 178,
     imageName:
       "b815e2c9a9017d15d34bba1425397a95b499090c9d960f8c01f6dc89f250b834.png",
@@ -10093,22 +10093,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10120,7 +10120,7 @@ const waccaSongs = [
     artist: "KO3 & Relect",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 190,
     imageName:
       "4b3864506e40834f01dcc108d6de0cc49563e1ff9968613e3a2cbe95c267375f.png",
@@ -10129,17 +10129,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10151,7 +10151,7 @@ const waccaSongs = [
     artist: "REDALiCE feat. 野宮あゆみ",
     dateAdded: 20210810,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 156,
     imageName:
       "25280b213975ea67579b9357816124bb7c45d208f085516695f6f66ef526d9c0.png",
@@ -10160,17 +10160,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10182,7 +10182,7 @@ const waccaSongs = [
     artist: "SIRO",
     dateAdded: 20210826,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 160,
     imageName:
       "02464df8f7fbc2eb87e8541dad8368d1e9548faac1e9b37d5e9136c1c265bb95.png",
@@ -10191,22 +10191,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 7.3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10218,7 +10218,7 @@ const waccaSongs = [
     artist: "YuNi",
     dateAdded: 20210826,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 140,
     imageName:
       "34a5cfe80c8fcd561992bc5ecb07e1b9ddd0f5712c517d39b48319d895c02a9b.png",
@@ -10227,17 +10227,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 7.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10249,7 +10249,7 @@ const waccaSongs = [
     artist: "ミライアカリ",
     dateAdded: 20210826,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 158,
     imageName:
       "9acfb2799d1441be4c93d667f14cdd178b28cc8114726d523056d063f621ea5a.png",
@@ -10258,17 +10258,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10280,7 +10280,7 @@ const waccaSongs = [
     artist: "DJ Myosuke & Laur",
     dateAdded: 20210909,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 200,
     imageName:
       "01b1ab3218b98d39e1489fd6bba704f0668f1ae2d7cd0c9182754f5bf16c886a.png",
@@ -10289,17 +10289,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10311,7 +10311,7 @@ const waccaSongs = [
     artist: "aran & t+pazolite",
     dateAdded: 20210909,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 180,
     imageName:
       "bdff7b505e30dad647d57954233f724b4eb6b52a7d58085850d2897e90d363b2.png",
@@ -10320,17 +10320,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10342,7 +10342,7 @@ const waccaSongs = [
     artist: "Getty & Srav3R & DJ Noriken",
     dateAdded: 20210909,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 175,
     imageName:
       "92ee1542d37e20b3184628c311f04a8671fd826d90d8b100b1e236b3b7f2788a.png",
@@ -10351,17 +10351,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10373,7 +10373,7 @@ const waccaSongs = [
     artist: "高宮なすの(鳴海杏子)",
     dateAdded: 20210923,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 154,
     imageName:
       "aa229c8d8c90d3aa974f35206387120a911fd27540ea7f18dba6d2b6c587c95d.png",
@@ -10382,17 +10382,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 7.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10404,7 +10404,7 @@ const waccaSongs = [
     artist: "ひとしずく×やま△",
     dateAdded: 20211007,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 128,
     imageName:
       "557840c61c0b3e86120c07fd4f8e499b4f3e343a6b94f4861d8a82f274d29bde.png",
@@ -10413,17 +10413,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10435,7 +10435,7 @@ const waccaSongs = [
     artist: "OИE (song by ナナホシ管弦楽団)",
     dateAdded: 20211007,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 180,
     imageName:
       "b6fc5227e6ebabdffb7ab17e7fea9ae3165346d2c3aa3514479e00637c42d322.png",
@@ -10444,17 +10444,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10466,7 +10466,7 @@ const waccaSongs = [
     artist: "ダイナミック自演ズ",
     dateAdded: 20211007,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 181,
     imageName:
       "19aef4366d5f8430e56a95a3c1603f849106de6541c4d6a070b18e2ac05bb299.png",
@@ -10475,17 +10475,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10497,7 +10497,7 @@ const waccaSongs = [
     artist: "wowaka",
     dateAdded: 20211021,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 171,
     imageName:
       "f84f4ee0cf7527a23d05d877137c94827ffe09796f4fef2cc5a5ee4c1962f306.png",
@@ -10506,17 +10506,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10528,7 +10528,7 @@ const waccaSongs = [
     artist: "iroha",
     dateAdded: 20211021,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 165,
     imageName:
       "274e4ac71da11274c2be3e0926037b685f36b9e7f3207895aacc82aee47f9702.png",
@@ -10537,17 +10537,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10559,7 +10559,7 @@ const waccaSongs = [
     artist: "cosMo＠暴走P feat.初音ミク",
     dateAdded: 20211021,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 190,
     imageName:
       "31e3b164c0827515f2a98302d9dfb89bd6ad29bcdcf25b6c258ea48ce6a210f4.png",
@@ -10568,17 +10568,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10590,7 +10590,7 @@ const waccaSongs = [
     artist: "Ayatsugu_Otowa",
     dateAdded: 20211111,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 180,
     imageName:
       "9b69a1f9c178d4e0032fb494dc2f1b2e64bf00d803a9add9997cbcc424fbef3b.png",
@@ -10599,17 +10599,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10621,7 +10621,7 @@ const waccaSongs = [
     artist: "モリモリあつし",
     dateAdded: 20211111,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 198,
     imageName:
       "b2faaf897e0842a9826215de35a09dbbc3122eba97b525fcfe16bbf66888aedf.png",
@@ -10630,17 +10630,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10652,7 +10652,7 @@ const waccaSongs = [
     artist: "MYUKKE.",
     dateAdded: 20211111,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 128,
     imageName:
       "f087b22e6acb98c9676eccc08a92753c37f6f662031def0c79b5aaf6d517acc6.png",
@@ -10661,17 +10661,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10683,7 +10683,7 @@ const waccaSongs = [
     artist: "DJ Myosuke & Gram",
     dateAdded: 20211118,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 202,
     imageName:
       "1050c89b965b5ccfdd7aa71c013318e17a2b258ef77423cf30f4b8229e415e19.png",
@@ -10692,17 +10692,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10714,7 +10714,7 @@ const waccaSongs = [
     artist: "DJ Noriken & aran",
     dateAdded: 20211118,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 180,
     imageName:
       "5e1b68f10175468f6fb5395a9f4fe8ee27535b813150607461123ce804e6c538.png",
@@ -10723,17 +10723,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10745,7 +10745,7 @@ const waccaSongs = [
     artist: "REDALiCE feat. 犬山たまき",
     dateAdded: 20211118,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 128,
     imageName:
       "90adcb85396dee6accd729726ee9e73d5d0c45abb19cf72a3e74f7a0962f7e2e.png",
@@ -10754,17 +10754,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10776,7 +10776,7 @@ const waccaSongs = [
     artist: "Sound piercer feat.DAZBEE",
     dateAdded: 20211202,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 187,
     imageName:
       "3f79bf851a2c72cd84d6f02199d1a3ff57dd3d7e72bd442f6938ef7909ca1f06.png",
@@ -10785,17 +10785,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10807,7 +10807,7 @@ const waccaSongs = [
     artist: "わかどり",
     dateAdded: 20211202,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 151,
     imageName:
       "8b1d7caf4d69011dcff629a7acd7e452451e118eb9307fa6ae82c503847d97f9.png",
@@ -10816,17 +10816,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10838,7 +10838,7 @@ const waccaSongs = [
     artist: "HIMEHINA",
     dateAdded: 20211209,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 150,
     imageName:
       "d4479681124a15fbfe98a8d5bca37b456f69a6686c05af6cc0cd173aaaa89b8f.png",
@@ -10847,17 +10847,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10869,7 +10869,7 @@ const waccaSongs = [
     artist: "Laur",
     dateAdded: 20211224,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 160,
     imageName:
       "07c3255b3148dc794c15d6c701572fba6e5ad49b78466e07b893648b0eaa3413.png",
@@ -10878,22 +10878,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10905,7 +10905,7 @@ const waccaSongs = [
     artist: "Kobaryo",
     dateAdded: 20211224,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 343,
     imageName:
       "8193056f16db5df3f3df8b0f09aa0b9245a6f1402d0bdfcdab92a7653922df70.png",
@@ -10914,22 +10914,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10941,7 +10941,7 @@ const waccaSongs = [
     artist: "aran",
     dateAdded: 20211224,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 202,
     imageName:
       "e657225f11be3ab8bcaa12bdf32a7eac623d9bff1f3742282abee5ab142ebe39.png",
@@ -10950,22 +10950,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -10977,7 +10977,7 @@ const waccaSongs = [
     artist: "REDALiCE",
     dateAdded: 20211224,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 230,
     imageName:
       "8073a6da9209aafc6ca44bb285f44c175f99cb9aa7257a0c27334d595e305c42.png",
@@ -10986,22 +10986,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14.2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11013,7 +11013,7 @@ const waccaSongs = [
     artist: "supercell",
     dateAdded: 20220113,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 170,
     imageName:
       "710913864d84c3b9735122f3e9c8689b2548243d71e86542a70a9fe2b3b93ee9.png",
@@ -11022,17 +11022,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11044,7 +11044,7 @@ const waccaSongs = [
     artist: "ゆうゆ",
     dateAdded: 20220113,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 232,
     imageName:
       "54350416bdfd1bf76f066353a232c084ef6bc1c29e65f82d2feebc58dcc49b20.png",
@@ -11053,17 +11053,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11075,7 +11075,7 @@ const waccaSongs = [
     artist: "亜沙",
     dateAdded: 20220113,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 192,
     imageName:
       "8f235c5325a066792f4d98680583ecb58e9de07907e015289254293fd6f25318.png",
@@ -11084,17 +11084,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11106,7 +11106,7 @@ const waccaSongs = [
     artist: "餓鬼レンジャー feat. 梅田サイファー",
     dateAdded: 20220120,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 180,
     imageName:
       "fd6af8df7600b3d57ae716667fb8b419ab22308bbc7a1cb5d81707f1d31ca804.png",
@@ -11115,17 +11115,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11138,7 +11138,7 @@ const waccaSongs = [
       "ギルガメッシュ（CV：大塚剛央）、千極兆司（CV：立花慎之介）、緋野天魔（CV：小野賢章）、神水鶴久遠（CV：広瀬裕也）、皇麗夢（CV：豊永利行）",
     dateAdded: 20220127,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 124,
     imageName:
       "cf8a0588221c6df6113c1272cb81f2baea39397909a695a0999a87f4b0ad47fc.png",
@@ -11147,17 +11147,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11169,7 +11169,7 @@ const waccaSongs = [
     artist: "NOMA",
     dateAdded: 20220210,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 150,
     imageName:
       "bdaad390ec2ac33073f45808d2bf21b67a04027e0bbca46af6cc9ce79b49d05d.png",
@@ -11178,17 +11178,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11200,7 +11200,7 @@ const waccaSongs = [
     artist: "SOUND HOLIC feat. Nana Takahashi",
     dateAdded: 20220224,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 160,
     imageName:
       "5263e5ad7885710afa7de0a24dbcf5e9c6dce238d7a76217dac02e3d0e392e99.png",
@@ -11209,17 +11209,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11231,7 +11231,7 @@ const waccaSongs = [
     artist: "t+pazolite",
     dateAdded: 20220224,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 195,
     imageName:
       "3a4125ea4df77a6859b2deb3da57676bf8b78679dfe103142cdaaba893da459f.png",
@@ -11240,17 +11240,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11262,7 +11262,7 @@ const waccaSongs = [
     artist: "DJ Myosuke vs MASAKI",
     dateAdded: 20220227,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 190,
     imageName:
       "865567c59e026a9158c09329f3add9d7e89acce088c63404b1379ac04f649e0c.png",
@@ -11271,22 +11271,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11298,7 +11298,7 @@ const waccaSongs = [
     artist: "DJ Genki feat. Yukacco",
     dateAdded: 20220324,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 180,
     imageName:
       "ccb1a73ba122fbc3cea84b93af708273aaec32317aab69981f6aad0e05a852a9.png",
@@ -11307,17 +11307,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11329,7 +11329,7 @@ const waccaSongs = [
     artist: "DJ Noriken",
     dateAdded: 20220324,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 150,
     imageName:
       "ea4949d6d210e5cc39264f213e75009484ef1117c74b6eb7f023bedd5394b6da.png",
@@ -11338,17 +11338,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11360,7 +11360,7 @@ const waccaSongs = [
     artist: "Camellia",
     dateAdded: 20220414,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 593,
     imageName:
       "186ab1faacc9a110e21720d8ef8c938fa3c9663a0900d414c529b75cdbf0a054.png",
@@ -11369,17 +11369,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11.2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11391,7 +11391,7 @@ const waccaSongs = [
     artist: "Kobaryo",
     dateAdded: 20220421,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 294,
     imageName:
       "c4c090bfadfd0f5466d5792efc2d9f61d83151269c378aab5874337a4dd54eea.png",
@@ -11400,17 +11400,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11422,7 +11422,7 @@ const waccaSongs = [
     artist: "USAO & Camellia",
     dateAdded: 20220428,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 230,
     imageName:
       "f66bc0febd20ef74724c9536ebbe49e2119690ba95f88f6d528b91ef70333245.png",
@@ -11431,22 +11431,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 15,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11458,7 +11458,7 @@ const waccaSongs = [
     artist: "USAO",
     dateAdded: 20220519,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 210,
     imageName:
       "43c5e74dc6566e6a75670b2e182ba09d6d000cf0d248dcb3c038ef4c17e4b809.png",
@@ -11467,17 +11467,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11489,7 +11489,7 @@ const waccaSongs = [
     artist: "TANO*C ALL STARS",
     dateAdded: 20220602,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 171,
     imageName:
       "8cc0ee2a847df260d8a54cb285f01cceb973bc82d0de9f05080d7e70dd98813d.png",
@@ -11498,17 +11498,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11520,7 +11520,7 @@ const waccaSongs = [
     artist: "DJ Genki",
     dateAdded: 20220624,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 170,
     imageName:
       "d3b5661ed6bdbf8a853abc501031963af3f0447694b138380b7280518b66ef67.png",
@@ -11529,17 +11529,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11551,7 +11551,7 @@ const waccaSongs = [
     artist: "USAO",
     dateAdded: 20220625,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 190,
     imageName:
       "5a04a672b3dcdedf0ff087a6af9f6529347ec78ab328973e1e0b93be6a2fec4d.png",
@@ -11560,17 +11560,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11582,7 +11582,7 @@ const waccaSongs = [
     artist: "Srav3R",
     dateAdded: 20220626,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 175,
     imageName:
       "75033e90fabe125346487ffb9c020068eb777ff7e0f1e912a190e4359ae371bd.png",
@@ -11591,17 +11591,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11613,7 +11613,7 @@ const waccaSongs = [
     artist: "DJ Noriken",
     dateAdded: 20220627,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 190,
     imageName:
       "4be7d138569ae06341edf21e7867f518a05c0004bade4a9bf17cf8817c820ca4.png",
@@ -11622,17 +11622,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11644,7 +11644,7 @@ const waccaSongs = [
     artist: "Getty",
     dateAdded: 20220628,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 300,
     imageName:
       "1e8d6071192528676916f710f00d3ac4fc3f810fec497b397c97502f57d1a98c.png",
@@ -11653,17 +11653,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11675,7 +11675,7 @@ const waccaSongs = [
     artist: "Kobaryo feat. HiTNEX-X",
     dateAdded: 20220629,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 208,
     imageName:
       "53b8f53f7457b7906c0e22ef7270c13aacb46bb120a2e73fe8b80ddb828aa494.png",
@@ -11684,17 +11684,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11706,7 +11706,7 @@ const waccaSongs = [
     artist: "aran",
     dateAdded: 20220630,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 128,
     imageName:
       "4063a2de8ba30c0a521b3da82a5fb79e9f89e1b9703f4b98b3f6dc2ac59d895a.png",
@@ -11715,17 +11715,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 7.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11737,7 +11737,7 @@ const waccaSongs = [
     artist: "t+pazolite",
     dateAdded: 20220701,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 200,
     imageName:
       "1f0eb902a3f0ecafccbbc41c990846779ae8bd1e593e475b7f010863e80e0007.png",
@@ -11746,17 +11746,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11768,7 +11768,7 @@ const waccaSongs = [
     artist: "Massive New Krew & RoughSketch",
     dateAdded: 20220702,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 210,
     imageName:
       "06de017ab06c6978dc0c4e4f6dd2946e699c9eec1785ba3cf1bedd664541a8b7.png",
@@ -11777,17 +11777,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11799,7 +11799,7 @@ const waccaSongs = [
     artist: "aran",
     dateAdded: 20220703,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 128,
     imageName:
       "d45bdc62e85c448777a90118ebaa7db366c79303b8eabceb505be036c2c8e45d.png",
@@ -11808,17 +11808,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 7.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11830,7 +11830,7 @@ const waccaSongs = [
     artist: "Srav3R",
     dateAdded: 20220704,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 126,
     imageName:
       "5ec702bd853d938f4f2d7cea547f21cdb0f7fffa36d1a00340e087eabfce269f.png",
@@ -11839,17 +11839,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 7.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11861,7 +11861,7 @@ const waccaSongs = [
     artist: "Kobaryo",
     dateAdded: 20220705,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 108,
     imageName:
       "e063963ef48c6219138e3b09cf3d8a2c656ce2e83cc3379616db37b65bdf3e0c.png",
@@ -11870,17 +11870,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11892,7 +11892,7 @@ const waccaSongs = [
     artist: "DJ Myosuke",
     dateAdded: 20220706,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 215,
     imageName:
       "43e99a4c0f732a587b31a715b64d2d80683677bed6e80368ecbb88e590a563a2.png",
@@ -11901,17 +11901,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11923,7 +11923,7 @@ const waccaSongs = [
     artist: "Gram",
     dateAdded: 20220707,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 200,
     imageName:
       "049f9ef5fa9c72034b0d13156ddb4d3f3af1d9d1f095fd049e867a186d88b501.png",
@@ -11932,17 +11932,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11954,7 +11954,7 @@ const waccaSongs = [
     artist: "Laur",
     dateAdded: 20220708,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 220,
     imageName:
       "bbf9cb183771a569bbfb95d96872a6c8f58787518754a425bb03403306995b92.png",
@@ -11963,17 +11963,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 11,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -11985,7 +11985,7 @@ const waccaSongs = [
     artist: "DJ Myosuke",
     dateAdded: 20220709,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 1,
     imageName:
       "6c5bb8a334eea44ab33714d1e3c40276eec1d9ba8b823dec6bb9fc90125000fa.png",
@@ -11994,17 +11994,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.7,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -12016,7 +12016,7 @@ const waccaSongs = [
     artist: "t+pazolite",
     dateAdded: 20220710,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 1962,
     imageName:
       "4838f8e3ed246cd9c5c083e75ebf8077f495b3e16a049976367f2b31ffc78466.png",
@@ -12025,17 +12025,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -12047,7 +12047,7 @@ const waccaSongs = [
     artist: "SAISEN TURN",
     dateAdded: 20220711,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 174,
     imageName:
       "b6a41fd7689d40967cc57f9d2506bd44786d12e97ba429bcae085ee833da1843.png",
@@ -12056,17 +12056,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -12078,7 +12078,7 @@ const waccaSongs = [
     artist: "Massive New Krew",
     dateAdded: 20220712,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 150,
     imageName:
       "8242e4e93dd621904dad91985d2595dc785fff604f6fe06d20db766285155266.png",
@@ -12087,22 +12087,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 14,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -12114,7 +12114,7 @@ const waccaSongs = [
     artist: "源屋",
     dateAdded: 20220713,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 175,
     imageName:
       "30e2e8134c41332e61f27904d12fca91cb62d545af765f9bdf65dc71d428b1c9.png",
@@ -12123,17 +12123,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 8.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -12145,7 +12145,7 @@ const waccaSongs = [
     artist: "P*Light",
     dateAdded: 20220714,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 175,
     imageName:
       "5a0f6f79be7e5e6ba4e2ff17a6e3c9393f526ecbc3fa45b57049b3a9634bd9e5.png",
@@ -12154,17 +12154,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.5,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -12176,7 +12176,7 @@ const waccaSongs = [
     artist: "REDALiCE",
     dateAdded: 20220715,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 176,
     imageName:
       "7c84622b3f7af0672506b7f28c8a25894c1710a02079af0de66ae08a11177478.png",
@@ -12185,17 +12185,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 10.2,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.9,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -12207,7 +12207,7 @@ const waccaSongs = [
     artist: "DJ Noriken",
     dateAdded: 20220716,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 170,
     imageName:
       "8b2f3f2e272fe0903b31dab95cfcf6547a12500fdd51d55b45d060a060f1a6af.png",
@@ -12216,17 +12216,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.1,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.4,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -12238,7 +12238,7 @@ const waccaSongs = [
     artist: "aran",
     dateAdded: 20220717,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 175,
     imageName:
       "f3b48f11be827f4048cb593db197d42c86c29ee579c38b93b0cf0f53e57664ff.png",
@@ -12247,17 +12247,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12.8,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -12270,7 +12270,7 @@ const waccaSongs = [
       "HARDCORE TANO*C & エリザベス（CV:大西沙織） & リリィ（CV:青木志貴） & ルーン（CV:河瀬茉希）",
     dateAdded: 20220718,
     dateRemoved: 0,
-    gameVersion: 5,
+    gameVersion: 300,
     bpm: 180,
     imageName:
       "7f79cf957915d73bb5b80703a6e84204a4bf99c18fd50a4a11d1bfeb3a1ab5ef.png",
@@ -12279,22 +12279,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 9.6,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 13.3,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
       {
         difficulty: 12,
-        gameVersion: 5,
+        gameVersion: 300,
         charter: "Marvelous",
       },
     ],
@@ -12306,7 +12306,7 @@ const waccaSongs = [
     artist: "ARuFa & t+pazolite & かめりあ",
     dateAdded: 20240702,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 205,
     imageName: "S04/uT_J_S04_001.png",
     category: "バラエティ",
@@ -12314,17 +12314,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「ヤス」",
       },
       {
         difficulty: 10.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「ヤス」",
       },
       {
         difficulty: 13.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "ななひらハリケーン/やくさんす？",
       },
     ],
@@ -12336,7 +12336,7 @@ const waccaSongs = [
     artist: "Synthion",
     dateAdded: 20240702,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 175,
     imageName: "S04/uT_J_S04_002.png",
     category: "バラエティ",
@@ -12344,17 +12344,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 9,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 13.2,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
     ],
@@ -12366,7 +12366,7 @@ const waccaSongs = [
     artist: "USAO & Yuta Imai",
     dateAdded: 20240702,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 200,
     imageName: "S04/uT_J_S04_003.png",
     category: "バラエティ",
@@ -12374,17 +12374,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 10,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 13.8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
     ],
@@ -12396,7 +12396,7 @@ const waccaSongs = [
     artist: "yama",
     dateAdded: 20240702,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 120,
     imageName: "S04/uT_J_S04_008.png",
     category: "アニメ／ＰＯＰ",
@@ -12404,17 +12404,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Kursain",
       },
       {
         difficulty: 7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Kursain",
       },
       {
         difficulty: 12.2,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Kursain",
       },
     ],
@@ -12426,7 +12426,7 @@ const waccaSongs = [
     artist: "the peggies",
     dateAdded: 20240702,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 174,
     imageName: "S04/uT_J_S04_019.png",
     category: "アニメ／ＰＯＰ",
@@ -12434,17 +12434,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Kursain",
       },
       {
         difficulty: 8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Kursain",
       },
       {
         difficulty: 12.5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Kursain",
       },
     ],
@@ -12456,7 +12456,7 @@ const waccaSongs = [
     artist: "青春コンプレックス",
     dateAdded: 20240702,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 190,
     imageName: "S04/uT_J_S04_020.png",
     category: "アニメ／ＰＯＰ",
@@ -12464,17 +12464,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "あど・ざ・さみい！",
       },
       {
         difficulty: 7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "あど・ざ・さみい！",
       },
       {
         difficulty: 11.5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "あど・ざ・さみい！",
       },
     ],
@@ -12486,7 +12486,7 @@ const waccaSongs = [
     artist: "uma",
     dateAdded: 20240702,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 165,
     imageName: "S04/uT_J_S04_021.png",
     category: "バラエティ",
@@ -12494,17 +12494,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「YASU」",
       },
       {
         difficulty: 9.3,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「YASU」",
       },
       {
         difficulty: 13.1,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「YASU」",
       },
     ],
@@ -12516,7 +12516,7 @@ const waccaSongs = [
     artist: "sasakure.UK",
     dateAdded: 20240702,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 230,
     imageName: "S04/uT_J_S04_035.png",
     category: "ボカロ",
@@ -12524,22 +12524,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 9.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 12.1,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 13.8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "SNOWBÅLL(大未来雪玉)",
       },
     ],
@@ -12551,7 +12551,7 @@ const waccaSongs = [
     artist: "nm-y feat. AKA",
     dateAdded: 20240702,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 200,
     imageName: "S04/uT_J_S04_036.png",
     category: "バラエティ",
@@ -12559,22 +12559,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Tairitsu",
       },
       {
         difficulty: 10.6,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Tairitsu ft. Irrena",
       },
       {
         difficulty: 13.5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "靖",
       },
 	  {
         difficulty: 14.2,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "CODE:Seraphina",
       },
     ],
@@ -12586,7 +12586,7 @@ const waccaSongs = [
     artist: "inabakumori",
     dateAdded: 20240702,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 147,
     imageName: "S04/uT_J_S04_039.png",
     category: "ボカロ",
@@ -12594,22 +12594,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 1,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「YASU」",
       },
       {
         difficulty: 8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「YASU」",
       },
       {
         difficulty: 11.8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「YASU」",
       },
       {
         difficulty: 13.2,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "やくさんす？",
       },
     ],
@@ -12621,7 +12621,7 @@ const waccaSongs = [
     artist: "ETIA.",
     dateAdded: 20240702,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 175,
     imageName: "S04/uT_J_S04_028.png",
     category: "バラエティ",
@@ -12629,17 +12629,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Tairitsu",
       },
       {
         difficulty: 10.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Tairitsu",
       },
       {
         difficulty: 13.9,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Tairitsu",
       },
     ],
@@ -12651,7 +12651,7 @@ const waccaSongs = [
     artist: "aran",
     dateAdded: 20240702,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 126,
     imageName: "S04/uT_J_S04_041.png",
     category: "TANO*C",
@@ -12659,17 +12659,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「ヤス」",
       },
       {
         difficulty: 8.4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「ヤス」",
       },
       {
         difficulty: 12.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "タノシストアカスタマ",
       },
     ],
@@ -12681,7 +12681,7 @@ const waccaSongs = [
     artist: "Laur",
     dateAdded: 20250101,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: "160-256",
     imageName: "S04/uT_J_S04_014.png",
     category: "TANO*C",
@@ -12689,17 +12689,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 6,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「レイエズ」",
       },
       {
         difficulty: 10.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「ヤス」",
       },
       {
         difficulty: 13.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「ヤス VS レイエズ」",
       },
     ],
@@ -12711,7 +12711,7 @@ const waccaSongs = [
     artist: "REDALiCE feat. Ayumi Nomiya",
     dateAdded: 20250101,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 160,
     imageName: "S04/uT_J_S04_046.png",
     category: "東方アレンジ",
@@ -12719,17 +12719,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Gull vs. audi0",
       },
       {
         difficulty: 8.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Gull vs. Vespera H.Q. & audi0",
       },
       {
         difficulty: 11,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Gull vs. Vespera H.Q.",
       },
     ],
@@ -12741,7 +12741,7 @@ const waccaSongs = [
     artist: "DJ Myosuke",
     dateAdded: 20250101,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: "175 (dB)",
     imageName: "S04/uT_J_S04_048.png",
     category: "TANO*C",
@@ -12749,17 +12749,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「YASU」",
       },
       {
         difficulty: 10.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「YASU」",
       },
       {
         difficulty: 14,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「TERRORIZE THE ARCADE」",
       },
     ],
@@ -12771,7 +12771,7 @@ const waccaSongs = [
     artist: "DECO*27",
     dateAdded: 20250101,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 175,
     imageName: "S04/uT_J_S04_049.png",
     category: "ボカロ",
@@ -12779,17 +12779,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "♥あどれいぬさみい♥ vs. Lightning Sword",
       },
       {
         difficulty: 9.4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "♥あどれいぬさみい♥ vs. Lightning Sword",
       },
       {
         difficulty: 13.3,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "♥あどれいぬさみい♥ vs. Lightning Sword",
       },
     ],
@@ -12801,7 +12801,7 @@ const waccaSongs = [
     artist: "t+pazolite and Srav3R",
     dateAdded: 20250101,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 180,
     imageName: "S04/uT_J_S04_052.png",
     category: "TANO*C",
@@ -12809,17 +12809,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Tiiger 2023",
       },
       {
         difficulty: 9.9,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Tiiger 2023",
       },
       {
         difficulty: 12.6,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Tiiger vs. nb1rs 2023",
       },
     ],
@@ -12831,7 +12831,7 @@ const waccaSongs = [
     artist: "DJ NECOJITA",
     dateAdded: 20250125,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 175,
     imageName: "S04/uT_J_S04_055.png",
     category: "TANO*C",
@@ -12839,17 +12839,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "ngxbody.",
       },
       {
         difficulty: 8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "DJ NGOBODY.",
       },
       {
         difficulty: 12.5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
     ],
@@ -12861,7 +12861,7 @@ const waccaSongs = [
     artist: "nora2r",
     dateAdded: 20250125,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 175,
     imageName: "S04/uT_J_S04_056.png",
     category: "バラエティ",
@@ -12869,22 +12869,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "ヤ.ヤ.ス.ス.ヤ.ス.ス.",
       },
       {
         difficulty: 9,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "ヤ.ヤ.ス.ス.ヤ.ス.ス.",
       },
       {
         difficulty: 13.1,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "ヤ.ヤ.ス.ス.ヤ.ス.ス.",
       },
       {
         difficulty: 1,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: ".ス.ス.ヤ.ス.ス.ヤ.ヤ [ 戻 ]",
       },
     ],
@@ -12896,7 +12896,7 @@ const waccaSongs = [
     artist: "Caramella Girls",
     dateAdded: 20250125,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 165,
     imageName: "S04/uT_J_S04_004.png",
     category: "アニメ／ＰＯＰ",
@@ -12904,17 +12904,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Kursain vs Oakleyman",
       },
       {
         difficulty: 9.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Kursain vs Oakleyman",
       },
       {
         difficulty: 12.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Kursain vs Oakleyman",
       },
     ],
@@ -12926,7 +12926,7 @@ const waccaSongs = [
     artist: "t+pazolite",
     dateAdded: 20250125,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 200,
     imageName: "S04/uT_J_S04_058.png",
     category: "TANO*C",
@@ -12934,17 +12934,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "ソーラー・ヘキサ",
       },
       {
         difficulty: 10.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "ソーラー・ヘキサ",
       },
       {
         difficulty: 13.6,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "ソーラー・ヘキサ",
       },
     ],
@@ -12956,7 +12956,7 @@ const waccaSongs = [
     artist: "onumi VS DossyX",
     dateAdded: 20250125,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 172,
     imageName: "S04/uT_J_S04_061.png",
     category: "オリジナル",
@@ -12964,17 +12964,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "BEAVER BELIEVER",
       },
       {
         difficulty: 8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "BEAVER BELIEVER",
       },
       {
         difficulty: 12.3,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "ソーラー・ヘキサ",
       },
     ],
@@ -12986,7 +12986,7 @@ const waccaSongs = [
     artist: "Aiobahn feat. KOTOKO",
     dateAdded: 20250125,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 185,
     imageName: "S04/uT_J_S04_064.png",
     category: "バラエティ",
@@ -12994,17 +12994,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "SiameseDerp",
       },
       {
         difficulty: 9.9,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "SiameseDerp",
       },
       {
         difficulty: 13.5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "shinonome_atsushi vs. Vespera H.Q.",
       },
     ],
@@ -13016,7 +13016,7 @@ const waccaSongs = [
     artist: "Ado",
     dateAdded: 20250125,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 132,
     imageName: "S04/uT_J_S04_066.png",
     category: "バラエティ",
@@ -13024,22 +13024,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Lightning Sword",
       },
       {
         difficulty: 8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Oakleyman",
       },
       {
         difficulty: 12.4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Vespera H.Q.",
       },
       {
         difficulty: 13.4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "深红鬼 vs Lightning 唱",
       },
     ],
@@ -13051,7 +13051,7 @@ const waccaSongs = [
     artist: "USAO",
     dateAdded: 20250401,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 215,
     imageName: "S04/uT_J_S04_067.png",
     category: "バラエティ",
@@ -13059,17 +13059,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "saKe",
       },
       {
         difficulty: 9,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "saKe",
       },
       {
         difficulty: 13.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "saKe v.s. Vespera H.Q.",
       },
     ],
@@ -13081,7 +13081,7 @@ const waccaSongs = [
     artist: "SAWTOWNE",
     dateAdded: 20250401,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 170,
     imageName: "S04/uT_J_S04_068.png",
     category: "ボカロ",
@@ -13089,17 +13089,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "レイエズ ft. Lightning Sword",
       },
       {
         difficulty: 9,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Lightning Sword",
       },
       {
         difficulty: 13.2,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "レイエズ x Lightning Sword ft. Vespera H.Q.(R-18 edition)",
       },
     ],
@@ -13111,7 +13111,7 @@ const waccaSongs = [
     artist: "USAO",
     dateAdded: 20250401,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 205,
     imageName: "S04/uT_J_S04_069.png",
     category: "TANO*C",
@@ -13119,17 +13119,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Lightning Sword",
       },
       {
         difficulty: 10.5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Vespera H.Q.",
       },
       {
         difficulty: 14,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Vespera H.Q. vs Lightning Sword",
       },
     ],
@@ -13141,7 +13141,7 @@ const waccaSongs = [
     artist: "Yukopi",
     dateAdded: 20250401,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 135,
     imageName: "S04/uT_J_S04_070.png",
     category: "ボカロ",
@@ -13149,22 +13149,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 2,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「ヤス」",
       },
       {
         difficulty: 7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Kursain & audi0c0aster1",
       },
       {
         difficulty: 11.9,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Kursain ft. Vespera. H. Q.",
       },
       {
         difficulty: 13.1,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "「ヤス」",
       },
     ],
@@ -13176,7 +13176,7 @@ const waccaSongs = [
     artist: "crayvxn",
     dateAdded: 20250401,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 157,
     imageName: "S04/uT_J_S04_071.png",
     category: "バラエティ",
@@ -13184,17 +13184,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Binary",
       },
       {
         difficulty: 8.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Binary",
       },
       {
         difficulty: 13.4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Binary v.s. Lightning Sword",
       },
     ],
@@ -13206,7 +13206,7 @@ const waccaSongs = [
     artist: "C-Show",
     dateAdded: 20250401,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 128,
     imageName: "S04/uT_J_S04_072.png",
     category: "バラエティ",
@@ -13214,17 +13214,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 10,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 12.8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
     ],
@@ -13236,7 +13236,7 @@ const waccaSongs = [
     artist: "Zekk",
     dateAdded: 20250401,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 190,
     imageName: "S04/uT_J_S04_073.png",
     category: "バラエティ",
@@ -13244,17 +13244,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 10,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 13.8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
     ],
@@ -13266,7 +13266,7 @@ const waccaSongs = [
     artist: "Cosmograph",
     dateAdded: 20250401,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 90,
     imageName: "S04/uT_J_S04_074.png",
     category: "バラエティ",
@@ -13274,22 +13274,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Vespera H.Q.",
       },
       {
         difficulty: 9.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Oakleyman",
       },
       {
         difficulty: 13.4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "lI1176 (ヤス remix)",
       },
       {
         difficulty: 14,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "T Balls 2",
       },
     ],
@@ -13301,7 +13301,7 @@ const waccaSongs = [
     artist: "EasyPop",
     dateAdded: 20250401,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 127,
     imageName: "S04/uT_J_S04_076.png",
     category: "バラエティ",
@@ -13309,22 +13309,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 3,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "RocketW",
       },
       {
         difficulty: 7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "RocketW",
       },
       {
         difficulty: 10.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "twis v.s. Vespera H.Q.",
       },
       {
         difficulty: 12.3,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "tiiger ft. Vespera H.Q.",
       },
     ],
@@ -13336,7 +13336,7 @@ const waccaSongs = [
     artist: "Laur vs 大国奏音",
     dateAdded: 20250401,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 201,
     imageName: "S04/uT_J_S04_010.png",
     category: "バラエティ",
@@ -13344,22 +13344,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 11,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 13.3,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 14.1,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
     ],
@@ -13371,7 +13371,7 @@ const waccaSongs = [
     artist: "Schwank",
     dateAdded: 20250517,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: "140-260",
     imageName: "S04/uT_J_S04_030.png",
     category: "オリジナル",
@@ -13379,22 +13379,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "YUKIDAMA",
       },
       {
         difficulty: 11.6,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "<ヤス>",
       },
       {
         difficulty: 14.1,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "YUKIDAMA",
       },
       {
         difficulty: 15,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "�",
       },
     ],
@@ -13406,7 +13406,7 @@ const waccaSongs = [
     artist: "SubjectLoser",
     dateAdded: 20250517,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 190,
     imageName: "S04/uT_J_S04_087.png",
     category: "オリジナル",
@@ -13414,22 +13414,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "dandEGO",
       },
       {
         difficulty: 9.8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "fraudulentEGO",
       },
       {
         difficulty: 12.9,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "dandEGO vs. fraudulentEGO",
       },
       {
         difficulty: 14.0,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "WACCA PLUS FUMEN TEAM「小我」",
       },
     ],
@@ -13441,7 +13441,7 @@ const waccaSongs = [
     artist: "DJ Genki",
     dateAdded: 20250517,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 180,
     imageName: "S04/uT_J_S04_084.png",
     category: "TANO*C",
@@ -13449,17 +13449,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "ソーラー・ヘキサ",
       },
       {
         difficulty: 10,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "ソーラー・ヘキサ",
       },
       {
         difficulty: 13.7,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "ソーラー・ヘキサ",
       },
     ],
@@ -13471,7 +13471,7 @@ const waccaSongs = [
     artist: "F. Rabbeat feat. マスタード",
     dateAdded: 20250517,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 185,
     imageName: "S04/uT_J_S04_083.png",
     category: "バラエティ",
@@ -13479,17 +13479,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Tiiger",
       },
       {
         difficulty: 9,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Panaman",
       },
       {
         difficulty: 13.5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
     ],
@@ -13501,7 +13501,7 @@ const waccaSongs = [
     artist: "Mysteka",
     dateAdded: 20250517,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 180,
     imageName: "S04/uT_J_S04_082.png",
     category: "バラエティ",
@@ -13509,22 +13509,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 4,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Panaman",
       },
       {
         difficulty: 8.8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Panaman",
       },
       {
         difficulty: 10.6,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Panaman",
       },
       {
         difficulty: 13.1,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Panaman ft. Vespera H. Q.",
       },
     ],
@@ -13536,7 +13536,7 @@ const waccaSongs = [
     artist: "Sakuzyo",
     dateAdded: 20250517,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 150,
     imageName: "S04/uT_J_S04_040.png",
     category: "バラエティ",
@@ -13544,17 +13544,17 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "RocketW",
       },
       {
         difficulty: 9.8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "RocketW",
       },
       {
         difficulty: 13.8,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
     ],
@@ -13566,7 +13566,7 @@ const waccaSongs = [
     artist: "Team Grimoire",
     dateAdded: 20250517,
     dateRemoved: 0,
-    gameVersion: 6,
+    gameVersion: 400,
     bpm: 190,
     imageName: "S04/uT_J_S04_085.png",
     category: "バラエティ",
@@ -13574,22 +13574,22 @@ const waccaSongs = [
     sheets: [
       {
         difficulty: 5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Snowball",
       },
       {
         difficulty: 8.9,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "RocketW",
       },
       {
         difficulty: 13.5,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "Rocket-Propelled Snowball",
       },
       {
         difficulty: 14,
-        gameVersion: 6,
+        gameVersion: 400,
         charter: "ティンダロスより来たる風雪",
       },
     ],


### PR DESCRIPTION
This changes the `gameVersion` constants in the `waccaSongs.js` to reflect the versioning changes made in other places. Should fix rendering of the game version on the individual charts page.
![image](https://github.com/user-attachments/assets/dc96a378-c557-4859-ab19-7f831a4ae154)
