### PR TITLE
Fix tooltips for OLED mode

### DIFF
--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -28,7 +28,7 @@ const waccaOledTheme: ThemeDefinition = {
     navbar: "#000",
     surface: "#000",
     boxcolor: "#000",
-    "surface-variant": "#000",
+    "surface-variant": "#777777",
   },
 };
 const waccaLightPlusTheme: ThemeDefinition = {
@@ -57,7 +57,7 @@ const waccaOledPlusTheme: ThemeDefinition = {
     navbar: "#000",
     surface: "#000",
     boxcolor: "#000",
-    "surface-variant": "#000",
+    "surface-variant": "#777777",
   },
 };
 


### PR DESCRIPTION
Vuetify was making tooltips invisible in OLED mode, this fixes

Old:
<img width="476" height="147" alt="image" src="https://github.com/user-attachments/assets/66a4256d-44e4-4cc4-a24f-0dafe66f7aeb" />

Fix:
<img width="467" height="162" alt="image" src="https://github.com/user-attachments/assets/3541b90d-94b3-427f-a314-0bf388a8ed1b" />
