### PR TITLE
Add profile box scaling to stage up emblems (PoC)

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,7 +13,8 @@
         <div class="profile-icon">
           <WaccaIcon :icon="iconId" />
         </div>
-        <WaccaProfileBox ref="profileBoxRef">
+        <WaccaProfileBox ref="profileBoxRef"
+        :class="{ 'has-emblem': selectedVersionData?.dan_rank > 0 }">
           <div class="profile-box-column">
             <div>
               <span class="light">Welcome back</span>
@@ -90,8 +91,15 @@
   }
 
   :deep(.profile-box) {
+    align-items: center;
     padding-left: 70px;
+    box-sizing: border-box;
   }
+
+  :deep(.profile-box-wrapper.has-emblem .profile-box) {
+    padding-right: 160px;
+  }
+
 }
 
 .profile-box-column {
@@ -111,7 +119,7 @@
 }
 
 .stage-up {
-  margin-left: -40px;
+  margin-left: -160px;
   width: 150px;
 }
 


### PR DESCRIPTION
Just proof of concept for if we ever decide to have the profile box hold the stage up emblem
<img width="1727" height="493" alt="image" src="https://github.com/user-attachments/assets/e0ba1d31-54c4-4943-9172-96aad1f7d369" />
<img width="1673" height="491" alt="image" src="https://github.com/user-attachments/assets/2917243f-5385-4fdb-82a0-e41144e8735f" />
